### PR TITLE
📝 add version record to DynamoDB access patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,7 @@ Follow the ZeroAE [commit conventions](https://github.com/zeroae/.github/blob/ma
 | Get buckets | `PK=ENTITY#{id}, SK begins_with #BUCKET#` |
 | Get children | GSI1: `GSI1PK=PARENT#{id}` |
 | Resource capacity | GSI2: `GSI2PK=RESOURCE#{name}, SK begins_with BUCKET#` |
+| Get version | `PK=SYSTEM#, SK=#VERSION` |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Add missing `Get version` access pattern to DynamoDB Access Patterns table in CLAUDE.md

The `SYSTEM#/#VERSION` pattern was added with infrastructure versioning (#15) but wasn't documented.

## Test plan

- [x] Verify pattern matches `schema.py:pk_system()` and `schema.py:sk_version()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)