### PR TITLE
✨ add lambda-export command for custom deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,23 +14,21 @@ zae-limiter is a rate limiting library backed by DynamoDB using the token bucket
 ### Using uv (preferred)
 
 ```bash
-# Setup
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
+# Setup (one-time)
+uv sync --all-extras
 
 # Deploy infrastructure (CloudFormation)
-zae-limiter deploy --table-name rate_limits --region us-east-1
+uv run zae-limiter deploy --table-name rate_limits --region us-east-1
 
 # Run tests
-pytest
+uv run pytest
 
 # Type check
-mypy src/zae_limiter
+uv run mypy src/zae_limiter
 
 # Lint
-ruff check --fix .
-ruff format .
+uv run ruff check --fix .
+uv run ruff format .
 ```
 
 ### Using conda
@@ -95,6 +93,12 @@ zae-limiter deploy --table-name rate_limits --no-aggregator
 
 # Export template for custom deployment
 zae-limiter cfn-template > template.yaml
+
+# Export Lambda package for custom deployment
+zae-limiter lambda-export --output lambda.zip
+
+# Show Lambda package info without building
+zae-limiter lambda-export --info
 
 # Check stack status
 zae-limiter status --stack-name zae-limiter-rate_limits --region us-east-1


### PR DESCRIPTION
## Summary

- Add new `zae-limiter lambda-export` CLI command to export Lambda deployment package as a ZIP file
- Update `CLAUDE.md` to use `uv run` for all commands and `uv sync --all-extras` for setup

## Features

The new command supports:
- `--output/-o`: Specify output file path (default: `lambda.zip`)
- `--info`: Display package metadata without building
- `--force/-f`: Overwrite existing files without prompting

## Usage

```bash
# Export Lambda package
uv run zae-limiter lambda-export --output lambda.zip

# Show package info without building
uv run zae-limiter lambda-export --info
```

## Test plan

- [x] All 8 new tests pass for `TestLambdaExport`
- [x] Full test suite passes (130 tests)
- [x] mypy: no issues found
- [x] ruff: all checks pass
- [x] Manual verification of `--help` and `--info` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)