### PR TITLE
📝 add runnable example scripts for first release

### DIFF
--- a/examples/basic_rate_limiting.py
+++ b/examples/basic_rate_limiting.py
@@ -23,8 +23,8 @@ import asyncio
 
 from zae_limiter import (
     Limit,
-    RateLimitExceeded,
     RateLimiter,
+    RateLimitExceeded,
     SyncRateLimiter,
 )
 
@@ -73,7 +73,8 @@ async def async_main() -> None:
             # For API responses, use as_dict() for JSON serialization
             error_response = e.as_dict()
             print(f"  JSON response: error={error_response['error']}")
-            print(f"  Violations: {[v['limit_name'] for v in error_response['limits'] if v['exceeded']]}")
+            violations = [v["limit_name"] for v in error_response["limits"] if v["exceeded"]]
+            print(f"  Violations: {violations}")
 
     await limiter.close()
 

--- a/examples/hierarchical_limits.py
+++ b/examples/hierarchical_limits.py
@@ -24,8 +24,8 @@ import asyncio
 from zae_limiter import (
     EntityExistsError,
     Limit,
-    RateLimitExceeded,
     RateLimiter,
+    RateLimitExceeded,
 )
 
 # Configuration
@@ -106,7 +106,7 @@ async def main() -> None:
     # Check capacity on both entities
     key_available = await limiter.available("key-alice", "api", default_limits)
     proj_available = await limiter.available("proj-acme", "api", default_limits)
-    print(f"\nAfter 3 cascaded requests:")
+    print("\nAfter 3 cascaded requests:")
     print(f"  key-alice available: {key_available}")
     print(f"  proj-acme available: {proj_available}")
 

--- a/examples/llm_token_reconciliation.py
+++ b/examples/llm_token_reconciliation.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 
 from zae_limiter import (
     Limit,
-    RateLimitExceeded,
     RateLimiter,
+    RateLimitExceeded,
 )
 
 # Configuration


### PR DESCRIPTION
## Summary
- Add three runnable example scripts demonstrating key zae-limiter features
- All examples work with DynamoDB Local for easy local testing
- Prepares library for first public release (v0.1.0)

### Examples Added

1. **basic_rate_limiting.py** - Core API introduction
   - RateLimiter setup with DynamoDB Local
   - `Limit.per_minute()` factory methods
   - `RateLimitExceeded` exception handling
   - HTTP 429 response pattern (`as_dict()`, `retry_after_header`)
   - Both async and sync API examples

2. **llm_token_reconciliation.py** - Primary LLM use case
   - Multiple limits per call (rpm + tpm)
   - Token estimation before API call
   - Post-hoc reconciliation with `lease.adjust()`
   - Capacity checking with `available()` and `time_until_available()`

3. **hierarchical_limits.py** - Parent/child entities
   - Creating entity hierarchies (project → API keys)
   - Cascade mode (`cascade=True`)
   - Parent limits blocking child requests
   - Tier-based limits with `use_stored_limits=True`

## Test plan
- [ ] Start DynamoDB Local: `docker run -p 8000:8000 amazon/dynamodb-local`
- [ ] Run each example:
  - [ ] `uv run python examples/basic_rate_limiting.py`
  - [ ] `uv run python examples/llm_token_reconciliation.py`
  - [ ] `uv run python examples/hierarchical_limits.py`
- [ ] Verify CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)