### PR TITLE
🐛 make StackCreationError inherit from RateLimitError

### DIFF
--- a/src/zae_limiter/exceptions.py
+++ b/src/zae_limiter/exceptions.py
@@ -110,7 +110,7 @@ class EntityExistsError(RateLimitError):
         super().__init__(f"Entity already exists: {entity_id}")
 
 
-class StackCreationError(Exception):
+class StackCreationError(RateLimitError):
     """Raised when CloudFormation stack creation fails."""
 
     def __init__(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -261,6 +261,11 @@ class TestStackCreationError:
         assert "test-stack" in msg
         assert "permission denied" in msg
 
+    def test_inherits_from_rate_limit_error(self) -> None:
+        """StackCreationError extends RateLimitError."""
+        exc = StackCreationError("test-stack", "test reason")
+        assert isinstance(exc, RateLimitError)
+
 
 class TestStackAlreadyExistsError:
     """Tests for StackAlreadyExistsError."""


### PR DESCRIPTION
## Summary
Change `StackCreationError` to inherit from `RateLimitError` instead of `Exception` for consistent exception handling across the library.

## Breaking Changes
⚠️ **This is a breaking change:**
- `StackCreationError` now inherits from `RateLimitError`
- Code that catches `Exception` but not `RateLimitError` will no longer catch `StackCreationError`

**Migration:**
```python
# Before (still works)
try:
    manager.create_stack(...)
except StackCreationError:
    ...

# New capability (recommended)
try:
    manager.create_stack(...)
except RateLimitError:  # ✅ Now catches all library exceptions
    ...
```

## Benefits
- ✅ Consistent exception hierarchy
- ✅ Allows catching all library exceptions with a single `except RateLimitError`
- ✅ `StackAlreadyExistsError` also inherits from `RateLimitError` (via `StackCreationError`)

## Changes
- [exceptions.py:113](https://github.com/zeroae/zae-limiter/blob/fix/stack-creation-error-inheritance/src/zae_limiter/exceptions.py#L113): Changed base class from `Exception` to `RateLimitError`
- [test_exceptions.py:264-267](https://github.com/zeroae/zae-limiter/blob/fix/stack-creation-error-inheritance/tests/test_exceptions.py#L264-L267): Added test to verify inheritance

## Exception Hierarchy
```
Exception
└── RateLimitError (base for all library exceptions)
    ├── RateLimitExceeded
    ├── RateLimiterUnavailable
    ├── EntityNotFoundError
    ├── EntityExistsError
    ├── StackCreationError ⬅️ NOW inherits from RateLimitError
    │   └── StackAlreadyExistsError
    └── VersionError
        ├── VersionMismatchError
        ├── IncompatibleSchemaError
        └── InfrastructureNotFoundError
```

## Test Results
✅ All tests passing (263 passed, 19 skipped)
✅ New test added to verify inheritance
✅ Linting passed (ruff)
✅ Type checking passed (mypy)

## Related Issues
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)