### PR TITLE
♻️ remove create_table() and delete_table() methods

### DIFF
--- a/src/zae_limiter/limiter.py
+++ b/src/zae_limiter/limiter.py
@@ -606,18 +606,8 @@ class RateLimiter:
         )
 
     # -------------------------------------------------------------------------
-    # Table management
+    # Stack management
     # -------------------------------------------------------------------------
-
-    async def create_table(self) -> None:
-        """Create the DynamoDB table if it doesn't exist."""
-        await self._repository.create_table()
-        self._initialized = True
-
-    async def delete_table(self) -> None:
-        """Delete the DynamoDB table."""
-        await self._repository.delete_table()
-        self._initialized = False
 
     async def create_stack(
         self,
@@ -886,16 +876,8 @@ class SyncRateLimiter:
         )
 
     # -------------------------------------------------------------------------
-    # Table management
+    # Stack management
     # -------------------------------------------------------------------------
-
-    def create_table(self) -> None:
-        """Create the DynamoDB table if it doesn't exist."""
-        self._run(self._limiter.create_table())
-
-    def delete_table(self) -> None:
-        """Delete the DynamoDB table."""
-        self._run(self._limiter.delete_table())
 
     def create_stack(
         self,


### PR DESCRIPTION
## Summary

Removes deprecated `create_table()` and `delete_table()` methods from `RateLimiter` and `SyncRateLimiter` classes. This is a **breaking change** for v1.0.0 that removes direct table manipulation in favor of CloudFormation-based infrastructure management.

## Changes

- ❌ Removed `RateLimiter.create_table()` method
- ❌ Removed `RateLimiter.delete_table()` method  
- ❌ Removed `SyncRateLimiter.create_table()` method
- ❌ Removed `SyncRateLimiter.delete_table()` method
- 🔧 Updated section headers from "Table management" to "Stack management"

## Migration Guide

**Before (v0.x):**
```python
limiter = RateLimiter(table_name="rate_limits")
await limiter.create_table()
# ... use limiter ...
await limiter.delete_table()
```

**After (v1.0.0) - Option 1 (Auto-create):**
```python
limiter = RateLimiter(table_name="rate_limits", create_stack=True)
```

**After (v1.0.0) - Option 2 (CLI):**
```bash
zae-limiter deploy --table-name rate_limits --region us-east-1
limiter = RateLimiter(table_name="rate_limits")
```

**After (v1.0.0) - Option 3 (Manual):**
```python
limiter = RateLimiter(table_name="rate_limits")
await limiter.create_stack()  # Use stack management
await limiter.delete_stack()
```

## Testing

- ✅ All 263 tests pass (19 skipped)
- ✅ Coverage maintained at 83% (above 80% threshold)
- ✅ Linting and formatting clean
- ✅ Type checking passes with mypy strict mode
- ✅ No test changes needed (tests use Repository methods directly)

## Impact

This is a **breaking change** for v1.0.0:
- Users must migrate to CloudFormation-based infrastructure management
- Direct table manipulation methods are no longer available
- Infrastructure-as-code approach enforced for production use

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)