### PR TITLE
✨ enable DynamoDB Point-in-Time Recovery (PITR)

### DIFF
--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -48,8 +48,16 @@ Parameters:
     Default: '1.0.0'
     Description: Schema version for the rate limiter infrastructure
 
+  PITRRecoveryPeriodDays:
+    Type: String
+    Default: ''
+    Description: >
+      (Optional) Number of days for Point-in-Time Recovery period (1-35).
+      Leave empty to use AWS default (35 days). Not supported in all AWS partitions (e.g., aws-iso).
+
 Conditions:
   DeployAggregator: !Equals [!Ref EnableAggregator, 'true']
+  UsePITRRecoveryPeriod: !Not [!Equals [!Ref PITRRecoveryPeriodDays, '']]
 
 Resources:
   # -------------------------------------------------------------------------
@@ -107,6 +115,13 @@ Resources:
       StreamSpecification:
         StreamEnabled: true
         StreamViewType: NEW_AND_OLD_IMAGES
+
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+        RecoveryPeriodInDays: !If
+          - UsePITRRecoveryPeriod
+          - !Ref PITRRecoveryPeriodDays
+          - !Ref AWS::NoValue
 
       Tags:
         - Key: Application


### PR DESCRIPTION
## Summary

Enables Point-in-Time Recovery (PITR) for the DynamoDB table to provide data loss protection with configurable recovery periods.

**Key Features:**
- ✅ PITR enabled by default for all deployments
- ✅ Optional recovery period (1-35 days, defaults to AWS default of 35 days)
- ✅ AWS partition compatible (works with aws-iso by omitting unsupported fields)
- ✅ Backward compatible with existing deployments

## Changes

### CloudFormation Template Updates

1. **New Parameter:** `PITRRecoveryPeriodDays`
   - Type: String (defaults to empty)
   - Optional: Leave empty to use AWS default (35 days)
   - Range: 1-35 days when specified

2. **New Condition:** `UsePITRRecoveryPeriod`
   - Checks if user provided a custom recovery period
   - Uses `AWS::NoValue` to omit field when not specified

3. **DynamoDB Table Configuration:**
   - `PointInTimeRecoveryEnabled: true` (always enabled)
   - `RecoveryPeriodInDays`: Conditionally included only when specified

## Usage Examples

**Default deployment (35-day recovery period):**
```bash
zae-limiter deploy --table-name rate_limits --region us-east-1
```

**Custom recovery period:**
```bash
zae-limiter deploy --table-name rate_limits --region us-east-1 \
  --stack-parameters PITRRecoveryPeriodDays=7
```

**AWS ISO partitions (field automatically omitted):**
```bash
zae-limiter deploy --table-name rate_limits --region us-iso-east-1
```

## Test Plan

- [x] Template generates correctly with default parameters
- [x] Stack deploys successfully without recovery period parameter
- [x] CloudFormation parameter correctly defaults to empty string
- [x] Condition properly controls field inclusion using AWS::NoValue
- [x] CI checks pass (lint, type check, tests)

## Additional Context

- PITR provides continuous backups with per-second granularity
- Recovery window: 1-35 days (configurable recovery period is a new AWS feature from Jan 2025)
- Pricing: Based on table size, not recovery period length (~$0.20 per GB-month)
- Compatible with all AWS partitions by conditionally omitting `RecoveryPeriodInDays`

Resolves #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)