### PR TITLE
✨ add Lambda Dead Letter Queue for stream processing failures

### DIFF
--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -130,6 +130,35 @@ Resources:
   # -------------------------------------------------------------------------
   # Lambda Aggregator
   # -------------------------------------------------------------------------
+  AggregatorDLQ:
+    Type: AWS::SQS::Queue
+    Condition: DeployAggregator
+    Properties:
+      QueueName: !Sub ${TableName}-aggregator-dlq
+      MessageRetentionPeriod: 1209600  # 14 days (max retention)
+      VisibilityTimeout: 300  # 5 minutes
+      Tags:
+        - Key: Application
+          Value: zae-limiter
+
+  AggregatorDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAggregator
+    Properties:
+      AlarmName: !Sub ${TableName}-aggregator-dlq-alarm
+      AlarmDescription: Alert when messages appear in the aggregator DLQ
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Sum
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt AggregatorDLQ.QueueName
+      TreatMissingData: notBreaching
+
   AggregatorLogGroup:
     Type: AWS::Logs::LogGroup
     Condition: DeployAggregator
@@ -179,6 +208,13 @@ Resources:
                 Resource:
                   - !GetAtt RateLimitsTable.StreamArn
 
+              # DLQ access
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                Resource:
+                  - !GetAtt AggregatorDLQ.Arn
+
   AggregatorFunction:
     Type: AWS::Lambda::Function
     Condition: DeployAggregator
@@ -220,6 +256,14 @@ Resources:
       StartingPosition: LATEST
       BatchSize: 100
       MaximumBatchingWindowInSeconds: 5
+      MaximumRetryAttempts: 3
+      MaximumRecordAgeInSeconds: 3600  # 1 hour
+      BisectBatchOnFunctionError: true
+
+      # Send failed batches to DLQ
+      DestinationConfig:
+        OnFailure:
+          Destination: !GetAtt AggregatorDLQ.Arn
 
       # Filter to only process MODIFY events on BUCKET records
       FilterCriteria:
@@ -268,3 +312,24 @@ Outputs:
     Value: !Ref AggregatorFunction
     Export:
       Name: !Sub ${AWS::StackName}-AggregatorName
+
+  AggregatorDLQUrl:
+    Condition: DeployAggregator
+    Description: Aggregator Dead Letter Queue URL
+    Value: !Ref AggregatorDLQ
+    Export:
+      Name: !Sub ${AWS::StackName}-DLQUrl
+
+  AggregatorDLQArn:
+    Condition: DeployAggregator
+    Description: Aggregator Dead Letter Queue ARN
+    Value: !GetAtt AggregatorDLQ.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DLQArn
+
+  AggregatorDLQAlarmName:
+    Condition: DeployAggregator
+    Description: CloudWatch alarm for DLQ monitoring
+    Value: !Ref AggregatorDLQAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-DLQAlarmName


### PR DESCRIPTION
## Summary

Add SQS Dead Letter Queue (DLQ) to capture failed Lambda invocations from DynamoDB Streams, following AWS best practices for resilient event-driven architectures.

## Changes

### Infrastructure Resources
- **AggregatorDLQ**: SQS queue with 14-day retention for failed events
- **AggregatorDLQAlarm**: CloudWatch alarm monitoring DLQ message count
- **IAM Permissions**: Added `sqs:SendMessage` to AggregatorRole

### EventSourceMapping Configuration
- **DestinationConfig**: Routes failed batches to DLQ after retries
- **MaximumRetryAttempts**: 3 retries before sending to DLQ
- **MaximumRecordAgeInSeconds**: 1 hour max age for records
- **BisectBatchOnFunctionError**: Isolates poison pills without blocking stream

### Outputs
- `AggregatorDLQUrl`: SQS queue URL for programmatic access
- `AggregatorDLQArn`: ARN for IAM policies and integrations
- `AggregatorDLQAlarmName`: CloudWatch alarm identifier

## Best Practices Applied

1. **BisectBatchOnFunctionError**: Splits failed batches to isolate problematic records, preventing single poison pills from blocking the entire stream
2. **Limited Retries**: 3 max retries prevent infinite loops on persistent failures
3. **Extended Retention**: 14-day message retention allows ample time for investigation and reprocessing
4. **Proactive Monitoring**: CloudWatch alarm alerts when messages appear in DLQ

## Testing

- ✅ All existing tests pass
- ✅ CloudFormation template validates successfully
- ✅ DLQ resources conditionally deployed when `DeployAggregator=true`

## References

- [AWS: Gracefully handle failed Lambda events from DynamoDB Streams](https://aws.amazon.com/blogs/database/gracefully-handle-failed-aws-lambda-events-from-amazon-dynamodb-streams/)
- [AWS re:Post: Troubleshoot DynamoDB Streams in Lambda](https://repost.aws/knowledge-center/lambda-functions-fix-dynamodb-streams)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)