### PR TITLE
✨ add CloudWatch alarms for comprehensive monitoring

### DIFF
--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -55,9 +55,27 @@ Parameters:
       (Optional) Number of days for Point-in-Time Recovery period (1-35).
       Leave empty to use AWS default (35 days). Not supported in all AWS partitions (e.g., aws-iso).
 
+  EnableAlarms:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Whether to deploy CloudWatch alarms for monitoring
+
+  AlarmSNSTopicArn:
+    Type: String
+    Default: ''
+    Description: (Optional) SNS topic ARN for alarm notifications. Leave empty to skip SNS notifications.
+
 Conditions:
   DeployAggregator: !Equals [!Ref EnableAggregator, 'true']
   UsePITRRecoveryPeriod: !Not [!Equals [!Ref PITRRecoveryPeriodDays, '']]
+  DeployAlarms: !Equals [!Ref EnableAlarms, 'true']
+  DeployAggregatorAlarms: !And
+    - !Condition DeployAggregator
+    - !Condition DeployAlarms
+  HasSNSTopic: !Not [!Equals [!Ref AlarmSNSTopicArn, '']]
 
 Resources:
   # -------------------------------------------------------------------------
@@ -280,6 +298,119 @@ Resources:
                 }
               }
 
+  # -------------------------------------------------------------------------
+  # CloudWatch Alarms
+  # -------------------------------------------------------------------------
+  LambdaErrorRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAggregatorAlarms
+    Properties:
+      AlarmName: !Sub ${TableName}-aggregator-error-rate
+      AlarmDescription: Alert when Lambda error rate exceeds 1%
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AggregatorFunction
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSNSTopic
+        - [!Ref AlarmSNSTopicArn]
+        - !Ref AWS::NoValue
+
+  LambdaDurationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAggregatorAlarms
+    Properties:
+      AlarmName: !Sub ${TableName}-aggregator-duration
+      AlarmDescription: Alert when Lambda duration exceeds 48s (80% of 60s default timeout)
+      MetricName: Duration
+      Namespace: AWS/Lambda
+      Statistic: Average
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 2
+      Threshold: 48000  # 80% of default 60s timeout (48s in milliseconds)
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AggregatorFunction
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSNSTopic
+        - [!Ref AlarmSNSTopicArn]
+        - !Ref AWS::NoValue
+
+  DynamoDBReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${TableName}-read-throttle
+      AlarmDescription: Alert when DynamoDB read requests are throttled
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RateLimitsTable
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSNSTopic
+        - [!Ref AlarmSNSTopicArn]
+        - !Ref AWS::NoValue
+
+  DynamoDBWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAlarms
+    Properties:
+      AlarmName: !Sub ${TableName}-write-throttle
+      AlarmDescription: Alert when DynamoDB write requests are throttled
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 2
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RateLimitsTable
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSNSTopic
+        - [!Ref AlarmSNSTopicArn]
+        - !Ref AWS::NoValue
+
+  StreamIteratorAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: DeployAggregatorAlarms
+    Properties:
+      AlarmName: !Sub ${TableName}-stream-iterator-age
+      AlarmDescription: Alert when stream processing lag exceeds 30 seconds
+      MetricName: IteratorAge
+      Namespace: AWS/Lambda
+      Statistic: Maximum
+      Period: 300  # 5 minutes
+      EvaluationPeriods: 2
+      Threshold: 30000  # 30 seconds in milliseconds
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref AggregatorFunction
+      TreatMissingData: notBreaching
+      AlarmActions: !If
+        - HasSNSTopic
+        - [!Ref AlarmSNSTopicArn]
+        - !Ref AWS::NoValue
+
 Outputs:
   TableName:
     Description: DynamoDB table name
@@ -333,3 +464,38 @@ Outputs:
     Value: !Ref AggregatorDLQAlarm
     Export:
       Name: !Sub ${AWS::StackName}-DLQAlarmName
+
+  LambdaErrorRateAlarmName:
+    Condition: DeployAggregatorAlarms
+    Description: CloudWatch alarm for Lambda error rate
+    Value: !Ref LambdaErrorRateAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-LambdaErrorRateAlarmName
+
+  LambdaDurationAlarmName:
+    Condition: DeployAggregatorAlarms
+    Description: CloudWatch alarm for Lambda duration
+    Value: !Ref LambdaDurationAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-LambdaDurationAlarmName
+
+  DynamoDBReadThrottleAlarmName:
+    Condition: DeployAlarms
+    Description: CloudWatch alarm for DynamoDB read throttles
+    Value: !Ref DynamoDBReadThrottleAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-ReadThrottleAlarmName
+
+  DynamoDBWriteThrottleAlarmName:
+    Condition: DeployAlarms
+    Description: CloudWatch alarm for DynamoDB write throttles
+    Value: !Ref DynamoDBWriteThrottleAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-WriteThrottleAlarmName
+
+  StreamIteratorAgeAlarmName:
+    Condition: DeployAggregatorAlarms
+    Description: CloudWatch alarm for stream iterator age
+    Value: !Ref StreamIteratorAgeAlarm
+    Export:
+      Name: !Sub ${AWS::StackName}-StreamIteratorAgeAlarmName


### PR DESCRIPTION
## Summary

Add comprehensive CloudWatch alarms for proactive monitoring of Lambda and DynamoDB, following AWS best practices for threshold configuration and alarm design.

## Changes

### **5 New CloudWatch Alarms**

1. **LambdaErrorRateAlarm**: Alerts when Lambda errors exceed 1 per evaluation period
2. **LambdaDurationAlarm**: Alerts when Lambda duration exceeds 48s (80% of default 60s timeout)
3. **DynamoDBReadThrottleAlarm**: Alerts on any read throttling events
4. **DynamoDBWriteThrottleAlarm**: Alerts on any write throttling events
5. **StreamIteratorAgeAlarm**: Alerts when stream processing lag exceeds 30 seconds

### **Configuration Parameters**

- `EnableAlarms` (default: `true`): Master switch for all alarms
- `AlarmSNSTopicArn` (optional): SNS topic for alarm notifications

### **CloudFormation Conditions**

- `Deploy Alarms`: Controls DynamoDB alarms
- `DeployAggregatorAlarms`: Controls Lambda alarms (requires both `EnableAlarms` and `EnableAggregator`)
- `HasSNSTopic`: Conditionally adds SNS actions when topic ARN provided

### **Alarm Outputs**

All alarm names exported as stack outputs for programmatic access and monitoring dashboards.

## Best Practices Applied

### Threshold Configuration
- **Lambda error rate**: >1 error triggers alarm (low threshold for high reliability)
- **Lambda duration**: 48000ms (80% of 60s timeout per AWS recommendations)
- **DynamoDB throttles**: Any throttling triggers alarm (PAY_PER_REQUEST should never throttle)
- **Stream iterator age**: 30000ms (30s) indicates processing lag

### Alarm Design
- **Period**: 5 minutes for all alarms
- **Evaluation Periods**: 2 consecutive periods to reduce false positives
- **TreatMissingData**: `notBreaching` for graceful degradation
- **Optional SNS**: Conditional `AlarmActions` based on `AlarmSNSTopicArn` parameter

## Known Limitations

### Hardcoded Lambda Duration Threshold
The `LambdaDurationAlarm` threshold is currently hardcoded to 48000ms (80% of the default 60s `LambdaTimeout`).

**Rationale:**
- CloudFormation doesn't support arithmetic in resource properties
- Users cannot currently configure `LambdaTimeout` via CLI
- Hardcoding ensures the alarm works out-of-the-box

**Follow-up:** Created issue #60 to add CLI options for configurable timeouts and alarm thresholds.

## Testing

- ✅ All existing tests pass
- ✅ CloudFormation template validates successfully
- ✅ All 6 alarms present in generated template
- ✅ Conditional logic verified (alarms only deploy when enabled)

## AWS Best Practices References

- [AWS CloudWatch Recommended Alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html)
- [DynamoDB Monitoring Best Practices](https://aws.amazon.com/blogs/database/monitoring-amazon-dynamodb-for-operational-awareness/)
- [Lambda Error Monitoring](https://awsforengineers.com/blog/lambda-error-monitoring-best-practices/)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)