### PR TITLE
✨ add structured logging to Lambda processor

### DIFF
--- a/src/zae_limiter/aggregator/handler.py
+++ b/src/zae_limiter/aggregator/handler.py
@@ -1,14 +1,17 @@
 """Lambda handler for DynamoDB Stream events."""
 
 import os
+import time
 from typing import Any
 
-from .processor import process_stream_records
+from .processor import StructuredLogger, process_stream_records
 
 # Configuration from environment
 TABLE_NAME = os.environ.get("TABLE_NAME", "rate_limits")
 SNAPSHOT_WINDOWS = os.environ.get("SNAPSHOT_WINDOWS", "hourly,daily").split(",")
 SNAPSHOT_TTL_DAYS = int(os.environ.get("SNAPSHOT_TTL_DAYS", "90"))
+
+logger = StructuredLogger(__name__)
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -29,9 +32,29 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     Returns:
         Processing result summary
     """
+    start_time = time.perf_counter()
+    request_id = getattr(context, "aws_request_id", "unknown")
     records = event.get("Records", [])
 
+    logger.info(
+        "Lambda invocation started",
+        request_id=request_id,
+        function_name=getattr(context, "function_name", "unknown"),
+        record_count=len(records),
+        table_name=TABLE_NAME,
+        snapshot_windows=SNAPSHOT_WINDOWS,
+    )
+
     if not records:
+        processing_time_ms = (time.perf_counter() - start_time) * 1000
+        logger.info(
+            "Lambda invocation completed",
+            request_id=request_id,
+            processed=0,
+            snapshots_updated=0,
+            error_count=0,
+            processing_time_ms=round(processing_time_ms, 2),
+        )
         return {
             "statusCode": 200,
             "body": {"processed": 0, "snapshots_updated": 0, "errors": []},
@@ -42,6 +65,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         table_name=TABLE_NAME,
         windows=SNAPSHOT_WINDOWS,
         ttl_days=SNAPSHOT_TTL_DAYS,
+    )
+
+    processing_time_ms = (time.perf_counter() - start_time) * 1000
+    logger.info(
+        "Lambda invocation completed",
+        request_id=request_id,
+        processed=result.processed_count,
+        snapshots_updated=result.snapshots_updated,
+        error_count=len(result.errors),
+        processing_time_ms=round(processing_time_ms, 2),
     )
 
     return {


### PR DESCRIPTION
## Summary

- Add `StructuredLogger` class that outputs JSON to stdout for CloudWatch Logs Insights
- Log batch processing start/end with performance metrics (processing_time_ms)
- Log errors with full context (entity_id, resource, limit_name, window) and stack traces
- Add debug logging for successful snapshot updates
- Add Lambda invocation logging with request_id and function_name

## Example Log Output

```json
{"timestamp": "2026-01-11T12:00:00+00:00", "level": "INFO", "logger": "zae_limiter.aggregator.handler", "message": "Lambda invocation started", "request_id": "abc-123", "function_name": "aggregator", "record_count": 10}
{"timestamp": "2026-01-11T12:00:00+00:00", "level": "INFO", "logger": "zae_limiter.aggregator.processor", "message": "Batch processing completed", "processed_count": 10, "deltas_extracted": 5, "snapshots_updated": 10, "error_count": 0, "processing_time_ms": 42.5}
```

## CloudWatch Logs Insights Queries

```sql
-- Find all errors for an entity
fields @timestamp, message, entity_id, resource, exception
| filter level = "WARNING" and entity_id = "my-entity"
| sort @timestamp desc

-- Performance metrics
fields @timestamp, processing_time_ms, processed_count, snapshots_updated
| filter message = "Batch processing completed"
| stats avg(processing_time_ms), max(processing_time_ms) by bin(1h)
```

## Test plan

- [x] Unit tests pass (48 tests in test_processor.py)
- [x] Type check passes (mypy)
- [x] Lint passes (ruff)
- [x] Full test suite passes (283 tests)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)