### PR TITLE
✨ add context to RateLimiterUnavailable

### DIFF
--- a/src/zae_limiter/limiter.py
+++ b/src/zae_limiter/limiter.py
@@ -304,7 +304,13 @@ class RateLimiter:
                 yield Lease(repository=self._repository)
                 return
             else:
-                raise RateLimiterUnavailable(str(e), cause=e) from e
+                raise RateLimiterUnavailable(
+                    str(e),
+                    cause=e,
+                    table_name=self.table_name,
+                    entity_id=entity_id,
+                    resource=resource,
+                ) from e
 
         # Lease acquired successfully - manage the context
         try:


### PR DESCRIPTION
## Summary
- Add `table_name`, `entity_id`, and `resource` context fields to `RateLimiterUnavailable` exception
- Context is included in the exception message for improved debugging (e.g., `[table=rate_limits, entity=entity-1, resource=gpt-4]`)
- All context fields are optional keyword-only parameters

## Test plan
- [x] Unit tests for full context scenario
- [x] Unit tests for partial context scenario
- [x] All existing tests pass (285 passed)
- [x] Type check passes (mypy)
- [x] Lint passes (ruff)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)