### PR TITLE
🐛 fix integration tests after CloudFormation-always change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,11 @@ jobs:
         ports:
           - 4566:4566
         env:
-          SERVICES: dynamodb,dynamodbstreams,lambda,cloudformation,logs,iam
+          SERVICES: dynamodb,dynamodbstreams,lambda,cloudformation,logs,iam,cloudwatch,sqs
           DEBUG: 0
+          DOCKER_HOST: unix:///var/run/docker.sock
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
         options: >-
           --health-cmd "curl -f http://localhost:4566/_localstack/health"
           --health-interval 5s

--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -196,7 +196,7 @@ Resources:
 
   AggregatorDLQAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAggregator
+    Condition: DeployAggregatorAlarms
     Properties:
       AlarmName: !Sub ${TableName}-aggregator-dlq-alarm
       AlarmDescription: Alert when messages appear in the aggregator DLQ


### PR DESCRIPTION
## Summary

Fixes #70 - Integration tests now pass after PR #69 changed the library to always use CloudFormation for all deployments.

### Root Cause

The `AggregatorDLQAlarm` resource in the CloudFormation template had the wrong condition (`DeployAggregator` instead of `DeployAggregatorAlarms`). This caused the DLQ alarm to be created even when `enable_alarms=False`, which failed in LocalStack because CloudWatch wasn't enabled.

### Changes

- **Fix CFN template bug**: Change `AggregatorDLQAlarm` condition from `DeployAggregator` to `DeployAggregatorAlarms`
- **Add flexible test fixtures**: Create `minimal_stack_options`, `aggregator_stack_options`, and `full_stack_options` fixtures in `conftest.py`
- **Update CI workflow**: Add Docker socket mount for Lambda support, add `cloudwatch` and `sqs` services
- **Remove xfail markers**: All 9 previously failing tests now pass

### Test Results

| Test Category | Before | After |
|---------------|--------|-------|
| Integration tests | 9 XFAIL | 20 PASSED |
| Unit tests | 260 PASSED | 260 PASSED |

## Test plan

- [x] All 20 integration tests pass locally with LocalStack
- [x] All 260 unit tests pass
- [x] Linting (ruff) passes
- [ ] CI integration tests pass with new LocalStack configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)