### PR TITLE
✨ add VS Code worktree configuration for multi-session Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,14 @@ venv.bak/
 
 # IDEs
 .idea/
-.vscode/
+.vscode/*.local.json
+.vscode/launch.json
 *.swp
 *.swo
 *~
+
+# Worktrees
+*.worktrees/
 
 # mypy
 .mypy_cache/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "GitWorktrees.git-worktrees",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+    "gitWorktrees.worktrees.dir.path": "../zae-limiter.worktrees",
+    "gitWorktrees.move.openNewVscodeWindow": true,
+    "gitWorktrees.worktreeCopyIncludePatterns": [
+        ".vscode/settings.json",
+        ".env",
+        ".env.local"
+    ],
+    "python.defaultInterpreterPath": ".venv/bin/python",
+    "python.terminal.activateEnvironment": true,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        }
+    },
+    "ruff.path": [".venv/bin/ruff"],
+    "mypy-type-checker.path": [".venv/bin/mypy"],
+    "editor.rulers": [88, 120],
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true
+}


### PR DESCRIPTION
## Summary
- Configure Git Worktrees extension to store worktrees in `../zae-limiter.worktrees`
- Enable parallel Claude Code sessions in separate VS Code windows
- Add recommended extensions (Git Worktrees, Ruff, mypy, Python)
- Update `.gitignore` to allow shared `.vscode/` settings while ignoring local configs

## Test plan
- [x] Install Git Worktrees extension (`GitWorktrees.git-worktrees`)
- [x] Open command palette → "Git Worktree: Add" → select branch
- [x] Verify new VS Code window opens with worktree
- [x] Verify `.vscode/settings.json` is copied to new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)