### PR TITLE
♻️ use AWS::StackName instead of TableName parameter

### DIFF
--- a/docs/infra/cloudformation.md
+++ b/docs/infra/cloudformation.md
@@ -41,6 +41,8 @@ zae-limiter cfn-template | less
 
 ## Template Parameters
 
+The DynamoDB table name is automatically derived from the CloudFormation stack name using the `AWS::StackName` pseudo-parameter. This ensures consistency between stack and resource names.
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `SnapshotWindows` | String | `hourly,daily` | Comma-separated list of snapshot windows |
@@ -131,7 +133,7 @@ AggregatorFunction:
     Timeout: 60
     Environment:
       Variables:
-        TABLE_NAME: !Ref TableName
+        TABLE_NAME: !Ref AWS::StackName
         SNAPSHOT_WINDOWS: !Ref SnapshotWindows
         SNAPSHOT_TTL_DAYS: !Ref SnapshotRetentionDays
 ```
@@ -202,7 +204,7 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: CreateDLQ
     Properties:
-      QueueName: !Sub "${TableName}-aggregator-dlq"
+      QueueName: !Sub "${AWS::StackName}-aggregator-dlq"
       MessageRetentionPeriod: 1209600  # 14 days
 
   StreamEventMapping:
@@ -221,7 +223,7 @@ Resources:
 ReadThrottleAlarm:
   Type: AWS::CloudWatch::Alarm
   Properties:
-    AlarmName: !Sub "${TableName}-read-throttle"
+    AlarmName: !Sub "${AWS::StackName}-read-throttle"
     AlarmDescription: Alert when DynamoDB read requests are throttled
     MetricName: ReadThrottleEvents
     Namespace: AWS/DynamoDB
@@ -284,6 +286,8 @@ aws cloudformation deploy \
         EnableAlarms=true \
     --capabilities CAPABILITY_NAMED_IAM
 ```
+
+Note: The DynamoDB table name is automatically set to match the stack name (e.g., `ZAEL-prod`).
 
 ### Using SAM
 

--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -4,11 +4,6 @@ Description: >
   Lambda aggregator for usage snapshots.
 
 Parameters:
-  TableName:
-    Type: String
-    Default: ZAEL-rate-limits
-    Description: Name of the DynamoDB table (matches stack name with ZAEL- prefix)
-
   SnapshotWindows:
     Type: String
     Default: hourly,daily
@@ -139,7 +134,7 @@ Resources:
   RateLimitsTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Ref TableName
+      TableName: !Ref AWS::StackName
       BillingMode: PAY_PER_REQUEST
 
       AttributeDefinitions:
@@ -206,7 +201,7 @@ Resources:
     Type: AWS::SQS::Queue
     Condition: DeployAggregator
     Properties:
-      QueueName: !Sub ${TableName}-aggregator-dlq
+      QueueName: !Sub ${AWS::StackName}-aggregator-dlq
       MessageRetentionPeriod: 1209600  # 14 days (max retention)
       VisibilityTimeout: 300  # 5 minutes
       Tags:
@@ -217,7 +212,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAggregatorAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-aggregator-dlq-alarm
+      AlarmName: !Sub ${AWS::StackName}-aggregator-dlq-alarm
       AlarmDescription: Alert when messages appear in the aggregator DLQ
       MetricName: ApproximateNumberOfMessagesVisible
       Namespace: AWS/SQS
@@ -235,7 +230,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Condition: DeployAggregator
     Properties:
-      LogGroupName: !Sub /aws/lambda/${TableName}-aggregator
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-aggregator
       RetentionInDays: !Ref LogRetentionDays
 
   AggregatorRole:
@@ -245,7 +240,7 @@ Resources:
       RoleName: !If
         - HasCustomRoleName
         - !Ref RoleName
-        - !Sub ${TableName}-aggregator-role
+        - !Sub ${AWS::StackName}-aggregator-role
       PermissionsBoundary: !If
         - HasPermissionBoundary
         - !If
@@ -302,7 +297,7 @@ Resources:
     Condition: DeployAggregator
     DependsOn: AggregatorLogGroup
     Properties:
-      FunctionName: !Sub ${TableName}-aggregator
+      FunctionName: !Sub ${AWS::StackName}-aggregator
       Description: Aggregates rate limiter usage into hourly/daily snapshots
       Runtime: python3.12
       Handler: zae_limiter.aggregator.handler.handler
@@ -312,7 +307,7 @@ Resources:
 
       Environment:
         Variables:
-          TABLE_NAME: !Ref TableName
+          TABLE_NAME: !Ref AWS::StackName
           SNAPSHOT_WINDOWS: !Ref SnapshotWindows
           SNAPSHOT_TTL_DAYS: !Ref SnapshotRetentionDays
           ZAE_LIMITER_SCHEMA_VERSION: !Ref SchemaVersion
@@ -369,7 +364,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAggregatorAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-aggregator-error-rate
+      AlarmName: !Sub ${AWS::StackName}-aggregator-error-rate
       AlarmDescription: Alert when Lambda error rate exceeds 1%
       MetricName: Errors
       Namespace: AWS/Lambda
@@ -391,7 +386,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAggregatorAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-aggregator-duration
+      AlarmName: !Sub ${AWS::StackName}-aggregator-duration
       AlarmDescription: !Sub Alert when Lambda duration exceeds threshold (${LambdaDurationThreshold}ms)
       MetricName: Duration
       Namespace: AWS/Lambda
@@ -413,7 +408,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-read-throttle
+      AlarmName: !Sub ${AWS::StackName}-read-throttle
       AlarmDescription: Alert when DynamoDB read requests are throttled
       MetricName: ReadThrottleEvents
       Namespace: AWS/DynamoDB
@@ -435,7 +430,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-write-throttle
+      AlarmName: !Sub ${AWS::StackName}-write-throttle
       AlarmDescription: Alert when DynamoDB write requests are throttled
       MetricName: WriteThrottleEvents
       Namespace: AWS/DynamoDB
@@ -457,7 +452,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAggregatorAlarms
     Properties:
-      AlarmName: !Sub ${TableName}-stream-iterator-age
+      AlarmName: !Sub ${AWS::StackName}-stream-iterator-age
       AlarmDescription: Alert when stream processing lag exceeds 30 seconds
       MetricName: IteratorAge
       Namespace: AWS/Lambda

--- a/src/zae_limiter/infra/stack_manager.py
+++ b/src/zae_limiter/infra/stack_manager.py
@@ -104,13 +104,11 @@ class StackManager:
         if not parameters:
             # Use defaults from template with schema version
             return [
-                {"ParameterKey": "TableName", "ParameterValue": self.table_name},
                 {"ParameterKey": "SchemaVersion", "ParameterValue": schema_version},
             ]
 
         result = []
-        # Always include TableName and SchemaVersion
-        result.append({"ParameterKey": "TableName", "ParameterValue": self.table_name})
+        # Always include SchemaVersion
         result.append({"ParameterKey": "SchemaVersion", "ParameterValue": schema_version})
 
         # Map common parameter names

--- a/tests/unit/test_stack_manager.py
+++ b/tests/unit/test_stack_manager.py
@@ -30,11 +30,11 @@ class TestStackManager:
         manager = StackManager(stack_name="rate-limits", region="us-east-1")
         params = manager._format_parameters(None)
 
-        # Should include TableName and SchemaVersion
-        assert len(params) == 2
+        # Should include only SchemaVersion (TableName derived from AWS::StackName)
+        assert len(params) == 1
         param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
-        assert param_dict["TableName"] == "ZAEL-rate-limits"
         assert "SchemaVersion" in param_dict
+        assert "TableName" not in param_dict
 
     def test_format_parameters_with_values(self) -> None:
         """Test parameter formatting with custom values."""
@@ -47,11 +47,11 @@ class TestStackManager:
             }
         )
 
-        # Should include TableName, SchemaVersion, plus custom params
-        assert len(params) == 5
+        # Should include SchemaVersion plus custom params (TableName derived from AWS::StackName)
+        assert len(params) == 4
 
         param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
-        assert param_dict["TableName"] == "ZAEL-rate-limits"
+        assert "TableName" not in param_dict
         assert "SchemaVersion" in param_dict
         assert param_dict["SnapshotWindows"] == "hourly,daily,monthly"
         assert param_dict["SnapshotRetentionDays"] == "180"
@@ -66,11 +66,11 @@ class TestStackManager:
             }
         )
 
-        # Should include TableName, SchemaVersion, plus PITR parameter
-        assert len(params) == 3
+        # Should include SchemaVersion plus PITR parameter (TableName derived from AWS::StackName)
+        assert len(params) == 2
 
         param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
-        assert param_dict["TableName"] == "ZAEL-rate-limits"
+        assert "TableName" not in param_dict
         assert "SchemaVersion" in param_dict
         assert param_dict["PITRRecoveryPeriodDays"] == "7"
 
@@ -97,11 +97,11 @@ class TestStackManager:
             }
         )
 
-        # Should include TableName, SchemaVersion, plus log retention parameter
-        assert len(params) == 3
+        # SchemaVersion + log retention (TableName derived from AWS::StackName)
+        assert len(params) == 2
 
         param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
-        assert param_dict["TableName"] == "ZAEL-rate-limits"
+        assert "TableName" not in param_dict
         assert "SchemaVersion" in param_dict
         assert param_dict["LogRetentionDays"] == "90"
 


### PR DESCRIPTION
## Summary

- Remove redundant `TableName` parameter from CloudFormation template
- Replace all `!Ref TableName` with `!Ref AWS::StackName`
- Update `stack_manager.py` to stop passing `TableName` parameter
- Update documentation and tests to reflect the change

This ensures the DynamoDB table name always matches the stack name, eliminating configuration drift and simplifying maintenance.

## Test plan

- [x] Unit tests pass (433 passed)
- [x] LocalStack integration tests pass (24 passed)
- [x] E2E tests pass
- [x] Linter and type checker pass

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/code)