### PR TITLE
🐛 fix git-cliff regex to strip emoji prefixes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -39,25 +39,29 @@ filter_unconventional = true
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  # Remove emoji and extract type, scope, and message
-  { pattern = '^[^\w\s]+\s*(\w+)(\(([^\)]+)\))?:\s*(.*)$', replace = "${1}(${3}): ${4}" },
+  # Strip emoji prefix and normalize to conventional commit format
+  # Uses [^a-zA-Z]* instead of [^\w\s]+ because Rust regex doesn't reliably match Unicode emojis with \w
+  { pattern = '^[^a-zA-Z]*(feat|fix|docs|refactor|test|perf|chore|revert|style|ci)(\([^)]*\))?!?:\s*', replace = "${1}${2}: " },
+  # Convert GitHub auto-generated revert format: Revert "type(scope): msg" -> revert: msg
+  { pattern = '^Revert "([^"]+)"', replace = "revert: ${1}" },
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
   { message = "^feat", group = "<!-- 0 -->Features" },
   { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
-  { message = "^doc", group = "<!-- 2 -->Documentation" },
+  { message = "^docs", group = "<!-- 2 -->Documentation" },
   { message = "^perf", group = "<!-- 3 -->Performance" },
   { message = "^refactor", group = "<!-- 4 -->Refactoring" },
   { message = "^style", group = "<!-- 5 -->Styling" },
   { message = "^test", group = "<!-- 6 -->Testing" },
+  { message = "^ci", group = "<!-- 8 -->CI" },
   { message = "^chore\\(release\\): prepare for", skip = true },
   { message = "^chore\\(deps\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },
   { message = "^chore", group = "<!-- 7 -->Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 8 -->Security" },
-  { message = "^revert", group = "<!-- 9 -->Revert" },
+  { body = ".*security", group = "<!-- 9 -->Security" },
+  { message = "^revert", group = "<!-- 10 -->Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
## Summary
- Fixed git-cliff `commit_preprocessors` regex that wasn't stripping emoji prefixes from commit messages
- Root cause: Rust regex `[^\w\s]+` doesn't reliably match Unicode emojis
- Solution: Changed to `[^a-zA-Z]*` which matches any non-letter prefix

## Changes
- Updated emoji-stripping regex pattern
- Added `ci` commit type parser (was missing)
- Added preprocessor for GitHub auto-revert format (`Revert "..."`)
- Fixed `doc` -> `docs` typo in commit_parsers

## Impact
- v0.2.0 release notes only captured 6/54 commits due to this bug
- Release notes have been manually updated on GitHub
- Future releases will generate complete changelogs

## Test plan
- [x] Verified with `uvx git-cliff --config cliff.toml v0.1.0..v0.2.0`
- [x] All 52 conventional commits now properly grouped
- [x] Only 2 warnings remain (non-conventional planning commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)