### PR TITLE
📝 docs: update getting-started.md to use get_status() method

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,18 +152,19 @@ This is useful when infrastructure is managed separately (e.g., via CLI or Terra
 === "Programmatic"
 
     ```python
-    status = await limiter.stack_status()  # Async
+    status = await limiter.get_status()  # Async
     # or
-    status = limiter.stack_status  # Sync (property)
+    status = limiter.get_status()  # Sync
 
-    if status is None:
-        print("Stack does not exist")
-    elif status == "CREATE_COMPLETE":
+    if not status.available:
+        print("DynamoDB not reachable")
+    elif status.stack_status == "CREATE_COMPLETE":
         print("Stack is ready")
-    elif "IN_PROGRESS" in status:
-        print(f"Operation in progress: {status}")
-    elif "FAILED" in status:
-        print(f"Stack in failed state: {status}")
+        print(f"Latency: {status.latency_ms}ms")
+    elif status.stack_status and "IN_PROGRESS" in status.stack_status:
+        print(f"Operation in progress: {status.stack_status}")
+    elif status.stack_status and "FAILED" in status.stack_status:
+        print(f"Stack in failed state: {status.stack_status}")
     ```
 
 === "CLI"


### PR DESCRIPTION
## Summary

- Update `docs/getting-started.md` to use the new `get_status()` method instead of the deprecated `stack_status()` method
- The new method returns a `Status` dataclass with comprehensive infrastructure information

This is the final documentation fix needed to complete the v0.3.0 API Polish milestone.

## Checklist for #121 (v0.3.0 API Polish)

All success criteria are now complete:

- [x] All CLI commands have programmatic equivalents
- [x] No new deprecation warnings in user code  
- [x] CLAUDE.md updated with new API
- [x] Documentation updated

Documentation updates:

- [x] CLAUDE.md: Code examples using `failure_mode` → No references existed
- [x] `docs/guide/unavailability.md`: Parameter rename → Already updated
- [x] `docs/getting-started.md`: Programmatic status check → **Fixed in this PR**

## Test plan

- [x] `uv run mkdocs build` completes successfully
- [x] Code example matches `docs/infra/deployment.md` lines 59-69

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)