### PR TITLE
🐛 fix(ci): allow file writes in ADR enforcer workflow

### DIFF
--- a/.github/workflows/claude-adr-enforcer.yml
+++ b/.github/workflows/claude-adr-enforcer.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash,Write,Read,Glob,Grep,Task"
           prompt: |
             Run /adr audit --base ${{ github.base_ref }} to validate PR ${{ github.repository }}/pull/${{ github.event.pull_request.number }} against architectural decisions in docs/adr/.
 


### PR DESCRIPTION
## Summary
- Add `allowed_tools` to permit Bash, Write, Read, Glob, Grep, Task
- Fixes permission denial when Claude tries to create `.claude/audit-result.sh`

## Problem
The ADR enforcer workflow was blocked from writing the result script:
```
"permission_denials": [{"tool_name": "Bash", ...}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)