### PR TITLE
🐛 fix(ci): use .github/audit-result.sh path and claude_args

### DIFF
--- a/.claude/skills/adr/audit.md
+++ b/.claude/skills/adr/audit.md
@@ -49,7 +49,9 @@ If violations are found, ask if the user wants to:
 
 ## CI Output (GitHub Actions)
 
-When running in CI (detected via `CI=true` environment variable), write a result script to `.claude/audit-result.sh`. The workflow executes this script to determine pass/fail status.
+When running in CI (detected via `CI=true` environment variable), write a result script to `.github/audit-result.sh`. The workflow executes this script to determine pass/fail status.
+
+**Note:** Do not use `.claude/` directory as it is considered sensitive and writes will be blocked.
 
 ### Available GitHub Actions Commands
 

--- a/.github/workflows/claude-adr-enforcer.yml
+++ b/.github/workflows/claude-adr-enforcer.yml
@@ -27,19 +27,19 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Bash,Write,Read,Glob,Grep,Task"
+          claude_args: "--allowedTools Bash,Write,Read,Glob,Grep,Task"
           prompt: |
             Run /adr audit --base ${{ github.base_ref }} to validate PR ${{ github.repository }}/pull/${{ github.event.pull_request.number }} against architectural decisions in docs/adr/.
 
-            IMPORTANT: Write the result script to `.claude/audit-result.sh` as documented in .claude/skills/adr/audit.md.
+            IMPORTANT: Write the result script to `.github/audit-result.sh` as documented in .claude/skills/adr/audit.md.
             The script must use GitHub Actions annotations for inline PR feedback and exit with the appropriate code (0 for pass, 1 for violations).
 
       - name: Check ADR audit result
         if: always()
         run: |
-          if [ -f .claude/audit-result.sh ]; then
-            chmod +x .claude/audit-result.sh
-            ./.claude/audit-result.sh
+          if [ -f .github/audit-result.sh ]; then
+            chmod +x .github/audit-result.sh
+            ./.github/audit-result.sh
           else
             echo "::warning::ADR audit did not produce a result file"
           fi


### PR DESCRIPTION
## Summary
- Change output path from `.claude/` to `.github/` (sensitive dir blocked)
- Use `claude_args` with `--allowedTools` instead of invalid `allowed_tools` input

## Problem
1. `allowed_tools` is not a valid input - must use `claude_args: "--allowedTools ..."`
2. `.claude/` directory is sensitive - writes are blocked even with permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)