### PR TITLE
🐛 fix(ci): make ADR enforcer deterministic #216

### DIFF
--- a/.claude/skills/adr/audit.md
+++ b/.claude/skills/adr/audit.md
@@ -23,10 +23,25 @@ Audit ADR-NNN compliance for this codebase.
 **Mode:** [diff against <branch> | full scan]
 **Files to check:** [list of files or "all src/**/*.py"]
 
-Instructions:
-1. Read the ADR and extract the Decision section
-2. Check if the specified files comply with the Decision
-3. Return findings in this format:
+## Compliance Criteria (CRITICAL - follow exactly)
+
+A violation exists ONLY when:
+1. The Decision section contains explicit prose requirements (e.g., "must use X", "Repository owns Y")
+2. The code contradicts that explicit requirement
+
+A violation does NOT exist when:
+- Code has additional methods/parameters not mentioned in the ADR
+- Implementation differs from illustrative examples (per ADR-000, code examples are excluded from ADRs)
+- The ADR describes patterns without mandating specific implementations
+
+## Instructions
+
+1. Read the ADR Decision section
+2. Extract ONLY explicit requirements stated in prose (ignore any code examples)
+3. For each requirement, verify the code follows the stated pattern
+4. Report ONLY clear contradictions to explicit requirements
+
+Return findings in this format:
 
 | File | Line | ADR | Violation |
 |------|------|-----|-----------|

--- a/docs/adr/000-adr-format-standard.md
+++ b/docs/adr/000-adr-format-standard.md
@@ -26,6 +26,10 @@ All ADRs must follow this format:
    - Test cases
    - Phased rollout plans
    - Detailed cost calculations
+5. **Enforceable decisions** - Write decisions that can be deterministically verified:
+   - Use explicit prose requirements ("must use X", "Y owns Z")
+   - Avoid vague language ("should", "ideally", "consider")
+   - Link to issues for implementation details and examples
 
 ## Consequences
 

--- a/docs/adr/108-repository-protocol.md
+++ b/docs/adr/108-repository-protocol.md
@@ -7,239 +7,45 @@
 
 ## Context
 
-`RateLimiter` currently constructs its own `Repository` instance internally, tightly coupling business logic to DynamoDB. This creates several problems:
-
-1. **Testing friction**: Unit tests require mocking DynamoDB internals or using moto
-2. **Backend lock-in**: Users wanting Redis (#149), SQLite (#156), In-Memory (#157), Cosmos DB (#158), or Firestore (#159) would need invasive changes
-3. **Misplaced concerns**: `StackOptions` (DynamoDB infrastructure) is passed to `RateLimiter` (business logic)
-4. **Third-party integration**: External packages cannot implement backends without depending on zae-limiter
-
-The current API conflates data access configuration with rate limiting behavior:
-
-```python
-limiter = RateLimiter(
-    name="my-app",              # Data access
-    region="us-east-1",         # Data access
-    endpoint_url=None,          # Data access
-    stack_options=StackOptions(),  # Infrastructure (DynamoDB-specific)
-    on_unavailable=OnUnavailable.BLOCK,  # Business logic
-)
-```
+`RateLimiter` tightly couples business logic to DynamoDB by constructing its own `Repository` internally. This creates testing friction, backend lock-in, and misplaced infrastructure concerns. Users wanting alternative backends (Redis #149, SQLite #156, In-Memory #157) would need invasive changes, and third-party packages cannot implement backends without depending on zae-limiter.
 
 ## Decision
 
-### 1. Define RepositoryProtocol with `@runtime_checkable`
+Use Python's `typing.Protocol` with `@runtime_checkable` decorator to define `RepositoryProtocol`. This enables duck typing, third-party backends without zae-limiter dependency, and easy mock injection for testing.
 
-Use Python's `typing.Protocol` with `@runtime_checkable` decorator:
+**Key design choices:**
 
-```python
-from typing import Protocol, runtime_checkable
+1. **Protocol over ABC**: Any object with matching methods satisfies the protocol—no inheritance required
+2. **Infrastructure ownership**: Repository owns data access and infrastructure (`StackOptions`); RateLimiter owns business logic only
+3. **Method categorization**:
+   - Required: entity CRUD, bucket operations, transactions, limit config, lifecycle
+   - Optional: audit events, usage snapshots (backend-specific, not in protocol)
+   - Capability-gated: batch operations (detected via `capabilities` property)
+4. **Infrastructure API**: `ensure_infrastructure()` replaces `create_stack()`; `stack_options` passed to constructor, not method
 
-@runtime_checkable
-class RepositoryProtocol(Protocol):
-    """Protocol for rate limiter data backends."""
-
-    # Entity operations
-    async def get_entity(self, entity_id: str) -> Entity | None: ...
-    async def create_entity(self, entity_id: str, name: str | None = None,
-                           parent_id: str | None = None) -> Entity: ...
-    async def delete_entity(self, entity_id: str) -> None: ...
-
-    # Bucket operations
-    async def get_buckets(self, entity_id: str, resource: str) -> list[BucketState]: ...
-    async def get_or_create_bucket(self, entity_id: str, resource: str,
-                                   limit: Limit) -> BucketState: ...
-
-    # Transaction operations
-    async def transact_consume(self, entries: list[ConsumeEntry]) -> None: ...
-    async def transact_release(self, entries: list[ReleaseEntry]) -> None: ...
-
-    # Limit config operations
-    async def get_limits(self, entity_id: str, resource: str) -> list[Limit]: ...
-    async def set_limits(self, entity_id: str, limits: list[Limit],
-                        resource: str) -> None: ...
-
-    # Lifecycle
-    async def close(self) -> None: ...
-
-    # Properties
-    @property
-    def name(self) -> str: ...
-```
-
-### 2. Why Protocol over ABC
-
-| Aspect | Protocol | ABC |
-|--------|----------|-----|
-| Inheritance required | No | Yes |
-| Duck typing | Natural fit | Must inherit |
-| Third-party backends | No zae-limiter dependency needed | Must import base class |
-| Existing Repository | Works without changes | Needs to inherit |
-| Runtime checking | `isinstance(repo, RepositoryProtocol)` | `isinstance(repo, ABCRepository)` |
-
-Protocol is more Pythonic: any object with the right methods satisfies the protocol, enabling:
-- Third-party packages to implement backends without importing zae-limiter
-- Mock objects in tests without inheriting from a base class
-- Gradual adoption in existing codebases
-
-### 3. Required vs Optional Methods
-
-**Required (core rate limiting):**
-- `get_entity`, `create_entity`, `delete_entity` - Entity lifecycle
-- `get_buckets`, `get_or_create_bucket` - Token bucket access
-- `transact_consume`, `transact_release` - Atomic limit operations
-- `get_limits`, `set_limits` - Limit configuration
-- `close` - Resource cleanup
-- `name` property - Backend identifier
-
-**Required (infrastructure):**
-- `ensure_infrastructure()` - Ensures backend infrastructure exists. For DynamoDB,
-  creates CloudFormation stack using `stack_options` from constructor. No-op if
-  `stack_options` was not provided.
-
-**Optional (backend-specific, not in protocol):**
-- `get_audit_events()` - Audit logging (DynamoDB-specific schema)
-- `get_usage_snapshots()` - Usage aggregation (requires Lambda)
-
-**Capability-gated optimizations (detected via `capabilities` property):**
-- `batch_get_buckets()` - Batch bucket reads (DynamoDB `BatchGetItem`)
-
-Capability-gated methods are accessed after checking `capabilities.supports_*`:
-
-```python
-# RateLimiter checks capability before using optimization
-if repo.capabilities.supports_batch_operations:
-    buckets = await repo.batch_get_buckets(keys)
-else:
-    # Fallback to sequential get_buckets() calls
-    buckets = {}
-    for entity_id, resource, _ in keys:
-        for bucket in await repo.get_buckets(entity_id, resource):
-            buckets[(bucket.entity_id, bucket.resource, bucket.limit_name)] = bucket
-```
-
-Optional methods are accessed via backend-specific types, not the protocol.
-
-### 4. Infrastructure Management Belongs in Repository
-
-`StackOptions` moves from `RateLimiter` to `Repository`:
-
-```python
-# Repository owns infrastructure - pass stack_options to constructor
-repo = Repository(
-    name="my-app",
-    region="us-east-1",
-    stack_options=StackOptions(
-        lambda_memory=512,
-        enable_alarms=True,
-    ),
-)
-
-# Ensure infrastructure exists (uses stored stack_options)
-await repo.ensure_infrastructure()
-
-# RateLimiter owns business logic only
-limiter = RateLimiter(
-    repository=repo,
-    on_unavailable=OnUnavailable.BLOCK,
-)
-```
-
-**Key API change:** `ensure_infrastructure()` replaces `create_stack()`:
-- `stack_options` is passed to the Repository constructor, not to the method
-- `ensure_infrastructure()` is a no-op if `stack_options` is `None`
-- `create_stack()` is deprecated and emits `DeprecationWarning`
-
-This separation enables:
-- Redis backends that don't need CloudFormation
-- In-memory backends for testing with zero infrastructure
-- Clear ownership: Repository manages its own resources
-
-### 5. Deprecation Path for Old Constructor
-
-```python
-class RateLimiter:
-    def __init__(
-        self,
-        # New way (preferred)
-        repository: RepositoryProtocol | None = None,
-        # Old way (deprecated)
-        name: str | None = None,
-        region: str | None = None,
-        endpoint_url: str | None = None,
-        stack_options: StackOptions | None = None,
-        # Business logic config (not deprecated)
-        on_unavailable: OnUnavailable = OnUnavailable.BLOCK,
-    ):
-        if repository is not None:
-            if name is not None:
-                raise ValueError("Cannot specify both repository and name")
-            self._repo = repository
-        elif name is not None:
-            warnings.warn(
-                "Passing name/region/endpoint_url/stack_options directly to "
-                "RateLimiter is deprecated. Use Repository(...) instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._repo = Repository(
-                name=name,
-                region=region,
-                endpoint_url=endpoint_url,
-                stack_options=stack_options,
-            )
-        else:
-            self._repo = Repository(name="limiter")
-```
-
-Deprecated constructor will be removed in v2.0.0.
+See [#150](https://github.com/zeroae/zae-limiter/issues/150) for implementation details and method signatures.
 
 ## Consequences
 
 **Positive:**
-- Clean separation: Repository owns data + infrastructure, RateLimiter owns business logic
-- Backend flexibility: Redis (#149), SQLite (#156), In-Memory (#157) without breaking changes
-- Third-party extensibility: External packages can implement backends without zae-limiter dependency
-- Testability: Easy mock injection via protocol
-- Type safety: `@runtime_checkable` enables `isinstance()` checks
+- Clean separation of concerns (data vs business logic)
+- Backend flexibility without breaking changes
+- Third-party extensibility without zae-limiter dependency
+- Testability via mock injection
+- Type safety with `@runtime_checkable`
 
 **Negative:**
-- More verbose construction for simple cases (two objects instead of one)
+- More verbose construction (two objects instead of one)
 - Deprecation period requires maintaining both constructor signatures
-- Optional methods (audit, usage) require type narrowing to access
+- Optional methods require type narrowing to access
 
 ## Alternatives Considered
 
 ### Abstract Base Class (ABC)
-
-```python
-from abc import ABC, abstractmethod
-
-class ABCRepository(ABC):
-    @abstractmethod
-    async def get_entity(self, entity_id: str) -> Entity | None: ...
-```
-
-Rejected because:
-- Requires inheritance, preventing duck typing
-- Third-party backends must import and inherit from zae-limiter
-- Less Pythonic than Protocol for interface definitions
+Rejected: Requires inheritance, preventing duck typing; less Pythonic for interfaces.
 
 ### Keep StackOptions on RateLimiter
-
-Rejected because:
-- Conflates business logic with infrastructure management
-- Makes non-DynamoDB backends awkward (they'd ignore StackOptions)
-- Violates single responsibility principle
+Rejected: Conflates business logic with infrastructure; violates single responsibility.
 
 ### Separate Sync and Async Protocols
-
-```python
-class SyncRepositoryProtocol(Protocol): ...
-class AsyncRepositoryProtocol(Protocol): ...
-```
-
-Rejected because:
-- Increases protocol surface area
-- `SyncRateLimiter` can wrap async repository with `asyncio.run()`
-- Single protocol with async methods is simpler
+Rejected: Increases surface area; `SyncRateLimiter` can wrap async with `asyncio.run()`.

--- a/docs/adr/109-backend-capability-matrix.md
+++ b/docs/adr/109-backend-capability-matrix.md
@@ -7,16 +7,7 @@
 
 ## Context
 
-The RepositoryProtocol extraction (#150) enables multiple storage backends beyond DynamoDB. Several backend implementations are planned:
-
-- [#149](https://github.com/zeroae/zae-limiter/issues/149) - Redis (sub-millisecond latency)
-- [#156](https://github.com/zeroae/zae-limiter/issues/156) - SQLite (local development)
-- [#157](https://github.com/zeroae/zae-limiter/issues/157) - In-Memory (unit testing)
-- [#158](https://github.com/zeroae/zae-limiter/issues/158) - Cosmos DB (Azure)
-- [#159](https://github.com/zeroae/zae-limiter/issues/159) - Firestore (GCP)
-- [#160](https://github.com/zeroae/zae-limiter/issues/160) - OCI NoSQL (Oracle Cloud)
-
-Each backend has different capabilities based on the underlying technology. This ADR defines which features are required for all backends versus optional based on backend capabilities.
+The RepositoryProtocol extraction (#150) enables multiple storage backends (Redis #149, SQLite #156, In-Memory #157, Cosmos DB #158, Firestore #159, OCI NoSQL #160). Each backend has different capabilities. This ADR defines which features are required versus optional.
 
 ## Decision
 
@@ -25,155 +16,46 @@ Define a three-tier capability system:
 | Tier | Requirement | Examples |
 |------|-------------|----------|
 | **Core** | Required for all backends | Token bucket, entity CRUD, transactions |
-| **Standard** | Expected for production backends | Hierarchical limits, cascade, TTL |
-| **Extended** | Backend-specific, optional | Audit logging, usage snapshots, infrastructure management |
+| **Standard** | Expected for production | Hierarchical limits, cascade, TTL |
+| **Extended** | Backend-specific, optional | Audit logging, usage snapshots, infrastructure |
 
-### Feature Capability Matrix
+**Core features** (all backends MUST implement): entity CRUD, bucket operations, atomic transactions, limit configuration, lifecycle management.
 
-| Feature | DynamoDB | Redis | SQLite | In-Memory | Cosmos DB | Firestore | OCI NoSQL |
-|---------|----------|-------|--------|-----------|-----------|-----------|-----------|
-| **Core Features** |
-| Token bucket algorithm | Required | Required | Required | Required | Required | Required | Required |
-| Entity CRUD | Required | Required | Required | Required | Required | Required | Required |
-| Bucket CRUD | Required | Required | Required | Required | Required | Required | Required |
-| Atomic transactions | Required | Required | Required | Required | Required | Required | Required |
-| Limit configuration | Required | Required | Required | Required | Required | Required | Required |
-| **Standard Features** |
-| Hierarchical entities | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Cascade support | Yes | Lua script | Yes | Yes | TBD | Yes | TBD |
-| TTL/expiration | Native | Native | Manual | Manual | Native | Native | Native |
-| Optimistic locking | Yes | Yes | Yes | Yes | Yes | Yes | TBD |
-| **Extended Features** |
-| Audit logging | Native | Streams | Table | In-memory | Change Feed | Listeners | TBD |
-| Usage snapshots | Lambda | Consumer | Polling | Skip | Functions | Functions | TBD |
-| Infrastructure mgmt | CloudFormation | Manual | N/A | N/A | ARM/Terraform | Terraform | Terraform |
-| Change streams | DynamoDB Streams | Redis Streams | N/A | N/A | Change Feed | Real-time | TBD |
+**Standard features** (production backends SHOULD implement): hierarchical entities via `parent_id`, cascade support, TTL management, optimistic locking.
 
-### Core Features (Required)
+**Extended features** (declared via `BackendCapabilities`): audit logging, usage snapshots, infrastructure management, change streams, batch operations. Backends declare support via capability flags; RateLimiter checks before using.
 
-All backends MUST implement these `RepositoryProtocol` methods:
+### Capability Matrix
 
-```python
-@runtime_checkable
-class RepositoryProtocol(Protocol):
-    # Entity operations
-    async def get_entity(self, entity_id: str) -> Entity | None: ...
-    async def create_entity(self, entity_id: str, name: str | None = None,
-                           parent_id: str | None = None) -> Entity: ...
-    async def delete_entity(self, entity_id: str) -> None: ...
+| Backend | Audit | Snapshots | Infra Mgmt | Streams | Batch |
+|---------|-------|-----------|------------|---------|-------|
+| DynamoDB | Yes | Yes | CloudFormation | Yes | Yes |
+| Redis | Streams | Consumer | Manual | Yes | Pipeline |
+| SQLite | Table | Polling | N/A | No | No |
+| In-Memory | No | No | N/A | No | No |
+| Cosmos DB | TBD | TBD | ARM/Terraform | Yes | Bulk |
+| Firestore | TBD | TBD | Terraform | Yes | getAll |
 
-    # Bucket operations
-    async def get_buckets(self, entity_id: str, resource: str) -> list[BucketState]: ...
-    async def get_or_create_bucket(self, entity_id: str, resource: str,
-                                   limit: Limit) -> BucketState: ...
-
-    # Transaction operations (atomic)
-    async def transact_consume(self, entries: list[ConsumeEntry]) -> None: ...
-    async def transact_release(self, entries: list[ReleaseEntry]) -> None: ...
-
-    # Limit configuration
-    async def get_limits(self, entity_id: str, resource: str) -> list[Limit]: ...
-    async def set_limits(self, entity_id: str, limits: list[Limit],
-                        resource: str) -> None: ...
-
-    # Lifecycle
-    async def close(self) -> None: ...
-```
-
-### Standard Features (Production Backends)
-
-Production backends SHOULD implement:
-
-1. **Hierarchical entities**: Parent-child relationships via `parent_id`
-2. **Cascade support**: Check parent limits when `cascade=True`
-3. **TTL management**: Automatic cleanup of expired records
-4. **Optimistic locking**: Version-based conflict detection
-
-### Extended Features (Backend-Specific)
-
-Extended features are declared via capability flags:
-
-```python
-class BackendCapabilities:
-    """Declares what extended features a backend supports."""
-    supports_audit_logging: bool = False
-    supports_usage_snapshots: bool = False
-    supports_infrastructure_management: bool = False
-    supports_change_streams: bool = False
-    supports_batch_operations: bool = False
-
-class RepositoryProtocol(Protocol):
-    @property
-    def capabilities(self) -> BackendCapabilities: ...
-```
-
-### Capability Declaration by Backend
-
-| Backend | `audit_logging` | `usage_snapshots` | `infrastructure_management` | `change_streams` | `batch_operations` |
-|---------|-----------------|-------------------|-----------------------------|--------------------|-------------------|
-| DynamoDB | True | True | True | True | True |
-| Redis | True (Streams) | True (Consumer) | False | True | True (Pipeline) |
-| SQLite | True (Table) | True (Polling) | False | False | False |
-| In-Memory | False | False | False | False | False |
-| Cosmos DB | TBD | TBD | False | True | True (Bulk) |
-| Firestore | TBD | TBD | False | True | True (getAll) |
-| OCI NoSQL | TBD | TBD | False | TBD | TBD |
-
-### Audit Logging Implementation by Backend
-
-| Backend | Implementation | Notes |
-|---------|----------------|-------|
-| DynamoDB | Native table records | `PK=AUDIT#{entity_id}`, TTL-based retention |
-| Redis | Redis Streams | `XADD audit:{entity_id} *` with `MAXLEN` |
-| SQLite | Separate table | `audit_events` table with timestamp index |
-| In-Memory | Not supported | Testing backend, no persistence |
-| Cosmos DB | Change Feed consumer | Requires separate consumer process |
-| Firestore | Real-time listeners | Requires Cloud Functions trigger |
-
-### Usage Snapshots Implementation by Backend
-
-| Backend | Implementation | Notes |
-|---------|----------------|-------|
-| DynamoDB | Lambda via DynamoDB Streams | Aggregates from `total_consumed_milli` delta |
-| Redis | Separate consumer process | Consumes from Redis Streams |
-| SQLite | Polling-based aggregation | Periodic queries, manual trigger |
-| In-Memory | Not supported | Testing backend, skip snapshots |
-| Cosmos DB | Azure Functions via Change Feed | Similar pattern to DynamoDB |
-| Firestore | Cloud Functions via listeners | Similar pattern to DynamoDB |
-
-### Infrastructure Management by Backend
-
-| Backend | Tool | Notes |
-|---------|------|-------|
-| DynamoDB | CloudFormation | `StackOptions` for declarative infra |
-| Redis | Manual | User manages Redis cluster |
-| SQLite | N/A | File-based, no infrastructure |
-| In-Memory | N/A | No persistence |
-| Cosmos DB | ARM/Terraform | User manages via Azure tools |
-| Firestore | Terraform | User manages via GCP tools |
-| OCI NoSQL | Terraform | User manages via OCI tools |
+See [#150](https://github.com/zeroae/zae-limiter/issues/150) for method signatures and implementation details.
 
 ## Consequences
 
 **Positive:**
 - Clear contract for backend implementers
 - Users know what to expect from each backend
-- Core features guaranteed across all backends
-- Extensibility without breaking changes
+- Core features guaranteed; extensibility without breaking changes
 
 **Negative:**
 - Feature disparity between backends
-- Documentation must cover per-backend differences
-- Testing matrix grows with each backend
+- Documentation and testing matrix grows with each backend
 
 ## Alternatives Considered
 
-- **All features required**: Rejected; forces backends to implement features that don't fit their model (e.g., In-Memory with audit logging)
-- **No capability declaration**: Rejected; users can't discover what features are available
-- **Separate protocols per tier**: Rejected; overly complex, single protocol with capabilities is cleaner
+### All features required
+Rejected: Forces backends to implement unsuitable features (e.g., In-Memory with audit logging).
 
-## Related
+### No capability declaration
+Rejected: Users can't discover available features.
 
-- [ADR-001](001-single-table-dynamodb.md) - DynamoDB single-table design
-- [ADR-010](010-total-consumed-counter.md) - Consumption tracking for snapshots
-- [#150](https://github.com/zeroae/zae-limiter/issues/150) - Repository Protocol extraction
+### Separate protocols per tier
+Rejected: Overly complex; single protocol with capabilities is cleaner.

--- a/docs/adr/110-deprecation-constructor.md
+++ b/docs/adr/110-deprecation-constructor.md
@@ -7,244 +7,48 @@
 
 ## Context
 
-The current `RateLimiter` constructor accepts infrastructure-specific parameters directly:
-
-```python
-limiter = RateLimiter(
-    name="my-app",
-    region="us-east-1",
-    endpoint_url=None,
-    stack_options=StackOptions(),
-    on_unavailable=OnUnavailable.BLOCK,
-)
-```
-
-This design conflates business logic configuration (`on_unavailable`) with data access configuration (`name`, `region`, `endpoint_url`, `stack_options`). Issue #150 proposes extracting a `Repository` class and `RepositoryProtocol` to:
-
-1. **Separate concerns**: Repository owns data access + infrastructure; RateLimiter owns business logic
-2. **Enable testability**: Easy to inject mock repositories
-3. **Support future backends**: Protocol enables Redis (#149) without breaking changes
-4. **Relocate StackOptions**: It belongs on Repository (DynamoDB-specific)
+The `RateLimiter` constructor conflates business logic (`on_unavailable`) with data access configuration (`name`, `region`, `endpoint_url`, `stack_options`). Per ADR-108, Repository should own data access and infrastructure, while RateLimiter owns only business logic. This requires deprecating the old constructor parameters.
 
 ## Decision
 
-Deprecate the `name`, `region`, `endpoint_url`, and `stack_options` parameters on `RateLimiter` and `SyncRateLimiter` constructors. Introduce a new `repository` parameter that accepts a `RepositoryProtocol` instance.
+Deprecate `name`, `region`, `endpoint_url`, and `stack_options` parameters on `RateLimiter` and `SyncRateLimiter`. Introduce a `repository` parameter accepting `RepositoryProtocol`.
 
-### Current API (Deprecated in v0.5.0)
+**Deprecation rules:**
+1. Old parameters emit `DeprecationWarning` with `stacklevel=2`
+2. Passing both `repository` and `name` raises `ValueError`
+3. When neither provided, default to `Repository(name="limiter")` for backward compatibility
+4. Applies to both `RateLimiter` and `SyncRateLimiter`
 
-```python
-limiter = RateLimiter(
-    name="my-app",
-    region="us-east-1",
-    endpoint_url=None,
-    stack_options=StackOptions(),
-    on_unavailable=OnUnavailable.BLOCK,
-)
-```
-
-### New API (Preferred in v0.5.0+)
-
-```python
-from zae_limiter import RateLimiter, Repository, StackOptions
-
-repo = Repository(
-    name="my-app",
-    region="us-east-1",
-    endpoint_url=None,
-    stack_options=StackOptions(),
-)
-limiter = RateLimiter(
-    repository=repo,
-    on_unavailable=OnUnavailable.BLOCK,
-)
-```
-
-### Deprecation Warning
-
-When the old constructor signature is used, emit:
-
-```python
-warnings.warn(
-    "Passing name/region/endpoint_url/stack_options directly to "
-    "RateLimiter is deprecated. Use Repository(...) instead. "
-    "This will be removed in v2.0.0.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-```
-
-**stacklevel=2** ensures the warning points to the caller's code, not the `RateLimiter.__init__` method.
-
-### Parameter Conflict Handling
-
-If both `repository` and `name` are provided, raise `ValueError`:
-
-```python
-if repository is not None and name is not None:
-    raise ValueError(
-        "Cannot specify both 'repository' and 'name'. "
-        "Use Repository(name=...) instead."
-    )
-```
-
-### Default Behavior (Backward Compatibility)
-
-When neither `repository` nor `name` is provided, create a default repository for backward compatibility:
-
-```python
-if repository is None and name is None:
-    # Maintain backward compatibility: default to "limiter" name
-    self._repo = Repository(name="limiter")
-```
-
-This matches the current default behavior where `name` defaults to `"limiter"`.
-
-### Timeline
+**Timeline:**
 
 | Version | Behavior |
 |---------|----------|
-| v0.4.x and earlier | Only old constructor signature available |
-| v0.5.0 | Both signatures work; old emits `DeprecationWarning` |
-| v0.6.0 - v1.x | Deprecation warning remains |
-| v2.0.0 | Old parameters removed; only `repository` accepted |
+| v0.4.x | Only old signature |
+| v0.5.0 | Both work; old emits warning |
+| v0.6.0–v1.x | Warning remains |
+| v2.0.0 | Old parameters removed |
 
-### SyncRateLimiter
-
-`SyncRateLimiter` follows the same deprecation pattern:
-
-```python
-# Old (deprecated)
-sync_limiter = SyncRateLimiter(name="my-app", region="us-east-1")
-
-# New (preferred)
-repo = Repository(name="my-app", region="us-east-1")
-sync_limiter = SyncRateLimiter(repository=repo)
-```
+See [#150](https://github.com/zeroae/zae-limiter/issues/150) for migration guide and examples.
 
 ## Consequences
 
 **Positive:**
-
-- Clear separation between data access and business logic
-- Enables mock repositories for testing without AWS
-- Protocol-based design supports future backends (Redis, in-memory)
-- Type-safe API with better IDE support
-- Gradual migration path with 1+ major version deprecation cycle
+- Clear separation of concerns
+- Enables mock repositories for testing
+- Gradual migration with 1+ major version cycle
 
 **Negative:**
-
-- More verbose for simple cases (two objects instead of one)
-- Users must update code before v2.0.0 to avoid breakage
-- Documentation must cover both patterns during transition
-
-## Migration Guide
-
-### Basic Usage
-
-```python
-# Before (v0.4.x)
-limiter = RateLimiter(
-    name="my-app",
-    region="us-east-1",
-)
-
-# After (v0.5.0+)
-from zae_limiter import RateLimiter, Repository
-
-repo = Repository(name="my-app", region="us-east-1")
-limiter = RateLimiter(repository=repo)
-```
-
-### With Infrastructure Management
-
-```python
-# Before (v0.4.x)
-limiter = RateLimiter(
-    name="my-app",
-    region="us-east-1",
-    stack_options=StackOptions(
-        lambda_memory=512,
-        enable_alarms=True,
-    ),
-)
-
-# After (v0.5.0+)
-from zae_limiter import RateLimiter, Repository, StackOptions
-
-repo = Repository(
-    name="my-app",
-    region="us-east-1",
-    stack_options=StackOptions(
-        lambda_memory=512,
-        enable_alarms=True,
-    ),
-)
-limiter = RateLimiter(repository=repo)
-
-# Note: Infrastructure is created automatically on first use via
-# RateLimiter._ensure_initialized() which calls repo.ensure_infrastructure().
-# You can also call it explicitly:
-await repo.ensure_infrastructure()
-```
-
-### LocalStack Development
-
-```python
-# Before (v0.4.x)
-limiter = RateLimiter(
-    name="my-app",
-    endpoint_url="http://localhost:4566",
-    region="us-east-1",
-    stack_options=StackOptions(),
-)
-
-# After (v0.5.0+)
-repo = Repository(
-    name="my-app",
-    endpoint_url="http://localhost:4566",
-    region="us-east-1",
-    stack_options=StackOptions(),
-)
-limiter = RateLimiter(repository=repo)
-```
-
-### Sync Client
-
-```python
-# Before (v0.4.x)
-sync_limiter = SyncRateLimiter(name="my-app", region="us-east-1")
-
-# After (v0.5.0+)
-repo = Repository(name="my-app", region="us-east-1")
-sync_limiter = SyncRateLimiter(repository=repo)
-```
-
-## Documentation Updates Required
-
-| Document | Update Needed |
-|----------|---------------|
-| `docs/getting-started.md` | Update quickstart examples to use Repository |
-| `docs/guide/basic-usage.md` | Update all RateLimiter instantiation examples |
-| `docs/infra/deployment.md` | Update declarative infrastructure examples |
-| `docs/api/` | Document Repository class and RepositoryProtocol |
-| `docs/contributing/localstack.md` | Update development examples |
-| `CLAUDE.md` | Update Infrastructure Deployment section examples |
+- More verbose construction
+- Users must migrate before v2.0.0
+- Docs must cover both patterns during transition
 
 ## Alternatives Considered
 
-### Keep Parameters on RateLimiter, Add Repository as Optional
+### Keep Parameters, Add Repository as Optional
+Rejected: Creates ambiguity; doesn't achieve separation goal.
 
-Rejected: Creates ambiguity about which is preferred; doesn't achieve separation of concerns goal.
+### Remove Immediately (Breaking Change)
+Rejected: Violates semver; users face immediate breakage.
 
-### Remove Old Parameters Immediately (Breaking Change)
-
-Rejected: Violates semantic versioning principles; existing users would face immediate breakage without migration path.
-
-### Use Factory Function Instead of Constructor Change
-
-```python
-# Alternative considered
-limiter = RateLimiter.from_repository(repo)
-```
-
-Rejected: Adding a factory while keeping constructor creates two "right" ways to do things; cleaner to have single constructor with deprecation.
+### Factory Method (`RateLimiter.from_repository()`)
+Rejected: Two "right" ways; cleaner to have single constructor with deprecation.


### PR DESCRIPTION
## Summary
- Refactor ADRs 108, 109, 110 to comply with ADR-000 format (remove code examples, keep under 100 lines)
- Update audit skill with explicit compliance criteria (violations only for prose contradictions)
- Add enforceable decision guidelines to ADR-000

## Root Cause
The ADR enforcer was non-deterministic because ADR-108 contained detailed code examples that didn't match the actual implementation. Different LLM runs interpreted "compliance" differently, causing flaky CI.

## Solution
- Remove code examples from ADRs per ADR-000 (code examples belong in issues)
- Add explicit compliance criteria to audit skill: violations exist ONLY when code contradicts explicit prose requirements
- Ignore additional methods, implementation variations, and illustrative examples

## Test plan
- [x] Run `/adr audit` locally to verify deterministic results
- [x] Verify ADRs 108, 109, 110 are under 100 lines
- [x] Verify no code examples remain in refactored ADRs

Fixes #216

🤖 Generated with [Claude Code](https://claude.ai/code)