### PR TITLE
✨ feat(limiter): allow "/" in resource names for provider/model grouping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,27 @@ Users provide a short identifier (e.g., `my-app`), and the system uses it direct
 - `my.app` (periods not allowed)
 - `123app` (must start with letter)
 
+### Rate Limiting Resource Names
+
+Resource names (used in `acquire()`, `set_resource_defaults()`, etc.) have different rules than stack names:
+
+| Character | Allowed |
+|-----------|---------|
+| Letters | ✅ |
+| Numbers | ✅ (not first char) |
+| Underscore `_` | ✅ |
+| Hyphen `-` | ✅ |
+| Dot `.` | ✅ |
+| Slash `/` | ✅ (for provider/model grouping) |
+| Hash `#` | ❌ (DynamoDB delimiter) |
+
+**Valid resource names:**
+- `api`, `gpt-4`, `gpt-3.5-turbo`
+- `openai/gpt-4`, `anthropic/claude-3` (provider/model grouping)
+- `anthropic/claude-3/opus` (nested paths)
+
+**Note:** Limit names (e.g., `rpm`, `tpm`) do NOT allow slashes.
+
 ### Hot Partition Risk Mitigation (Issue #116)
 
 Cascade (`cascade=True`) causes parent entities to receive traffic proportional to child count. High-fanout parents (1000+ children) risk exceeding per-partition throughput (~3,000 RCU / 1,000 WCU).

--- a/src/zae_limiter/limiter.py
+++ b/src/zae_limiter/limiter.py
@@ -40,7 +40,7 @@ from .models import (
     UsageSnapshot,
     UsageSummary,
     validate_identifier,
-    validate_name,
+    validate_resource,
 )
 from .repository import Repository
 from .schema import DEFAULT_RESOURCE
@@ -746,7 +746,7 @@ class RateLimiter:
         """Internal acquire implementation."""
         # Validate inputs at API boundary
         validate_identifier(entity_id, "entity_id")
-        validate_name(resource, "resource")
+        validate_resource(resource)
 
         now_ms = int(time.time() * 1000)
 

--- a/src/zae_limiter/models.py
+++ b/src/zae_limiter/models.py
@@ -19,8 +19,12 @@ MAX_NAME_LENGTH = 64  # limit_name, resource
 IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-:@]*$")
 
 # Names: letter start, then alphanumeric + _ - .
-# Used for limit names (rpm, tpm) and resources (api, gpt-3.5-turbo)
+# Used for limit names (rpm, tpm)
 NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_.\-]*$")
+
+# Resources: letter start, then alphanumeric + _ - . /
+# Allows provider/model grouping (openai/gpt-4, anthropic/claude-3)
+RESOURCE_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_.\-/]*$")
 
 # The '#' character is used as a key delimiter in DynamoDB and must be forbidden
 FORBIDDEN_CHAR = "#"
@@ -92,6 +96,39 @@ def validate_name(value: str, field_name: str) -> None:
             value,
             "must start with a letter and contain only alphanumeric, "
             "underscore, hyphen, or dot characters",
+        )
+
+
+def validate_resource(value: str, field_name: str = "resource") -> None:
+    """
+    Validate a resource name.
+
+    Resource names allow "/" for provider/model grouping (e.g., openai/gpt-4).
+
+    Args:
+        value: The resource name to validate
+        field_name: Name of the field (for error messages)
+
+    Raises:
+        InvalidNameError: If validation fails
+    """
+    if not value:
+        raise InvalidNameError(field_name, value, "cannot be empty")
+
+    if len(value) > MAX_NAME_LENGTH:
+        raise InvalidNameError(field_name, value, f"exceeds maximum length of {MAX_NAME_LENGTH}")
+
+    if FORBIDDEN_CHAR in value:
+        raise InvalidNameError(
+            field_name, value, f"cannot contain '{FORBIDDEN_CHAR}' (reserved delimiter)"
+        )
+
+    if not RESOURCE_PATTERN.match(value):
+        raise InvalidNameError(
+            field_name,
+            value,
+            "must start with a letter and contain only alphanumeric, "
+            "underscore, hyphen, dot, or slash characters",
         )
 
 

--- a/src/zae_limiter/repository.py
+++ b/src/zae_limiter/repository.py
@@ -20,7 +20,7 @@ from .models import (
     UsageSnapshot,
     UsageSummary,
     validate_identifier,
-    validate_name,
+    validate_resource,
 )
 from .naming import normalize_stack_name
 
@@ -1076,7 +1076,7 @@ class Repository:
             limits: List of Limit configurations to store
             principal: Caller identity for audit logging
         """
-        validate_name(resource, "resource")
+        validate_resource(resource)
         client = await self._get_client()
 
         # Delete existing limits for this resource
@@ -1125,7 +1125,7 @@ class Repository:
         resource: str,
     ) -> list[Limit]:
         """Get stored default limit configs for a resource."""
-        validate_name(resource, "resource")
+        validate_resource(resource)
         client = await self._get_client()
 
         # ADR-105: Use eventually consistent reads for config (0.5 RCU vs 1 RCU)
@@ -1166,7 +1166,7 @@ class Repository:
             resource: Resource name
             principal: Caller identity for audit logging
         """
-        validate_name(resource, "resource")
+        validate_resource(resource)
         await self._delete_resource_defaults_internal(resource)
 
         # Log audit event


### PR DESCRIPTION
## Summary

- Add `RESOURCE_PATTERN` regex that allows `/` character in resource names
- Add `validate_resource()` function for resource-specific validation
- Update `limiter.py` and `repository.py` to use `validate_resource()` for resource validation
- Add comprehensive unit tests for slash in resource names
- Update `CLAUDE.md` with resource naming documentation

This enables intuitive resource naming that matches common LLM ecosystem conventions (e.g., `openai/gpt-4`, `anthropic/claude-3-opus`).

Entity IDs and limit names remain unchanged to preserve future path-based hierarchy options.

## Test plan

- [x] Verify `openai/gpt-4` is a valid resource name
- [x] Verify `anthropic/claude-3/opus` is a valid resource name (nested)
- [x] Verify `/gpt-4` is rejected (must start with letter)
- [x] Verify `gpt-4/` is valid (trailing slash allowed)
- [x] Verify limit names still reject `/` (e.g., `rpm/tpm` is invalid)
- [x] Verify entity IDs still reject `/` (e.g., `org/user` is invalid)
- [x] Run `uv run pytest tests/unit/test_models.py -v -k resource` to verify tests pass

Closes #264

🤖 Generated with [Claude Code](https://claude.ai/code)