### PR TITLE
👷 ci: skip Claude code review for draft PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,8 +15,8 @@ on:
 
 jobs:
   claude-review:
-    # Skip bot-initiated PRs (e.g., dependabot, renovate)
-    if: github.event.pull_request.user.type != 'Bot'
+    # Skip bot-initiated PRs and draft PRs
+    if: github.event.pull_request.user.type != 'Bot' && github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip running Claude code review on draft PRs
- The job now only runs when the PR is ready for review

## Test plan
- [x] Create a draft PR and verify Claude code review is skipped
- [x] Mark draft as ready and verify Claude code review runs

🤖 Generated with [Claude Code](https://claude.ai/code)