### PR TITLE
📝 docs: update CI badge URLs for split workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![Conda version](https://img.shields.io/conda/v/conda-forge/zae-limiter?style=flat-square)](https://anaconda.org/conda-forge/zae-limiter)
 [![Python versions](https://img.shields.io/pypi/pyversions/zae-limiter?style=flat-square)](https://pypi.org/project/zae-limiter/)
 [![License](https://img.shields.io/pypi/l/zae-limiter?style=flat-square)](https://github.com/zeroae/zae-limiter/blob/main/LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci.yml?branch=main&style=flat-square)](https://github.com/zeroae/zae-limiter/actions/workflows/ci.yml)
+[![Lint](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci-lint.yml?branch=main&style=flat-square&label=lint)](https://github.com/zeroae/zae-limiter/actions/workflows/ci-lint.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci-tests.yml?branch=main&style=flat-square&label=tests)](https://github.com/zeroae/zae-limiter/actions/workflows/ci-tests.yml)
 [![codecov](https://img.shields.io/codecov/c/github/zeroae/zae-limiter?style=flat-square)](https://codecov.io/gh/zeroae/zae-limiter)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://zeroae.github.io/zae-limiter/)
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -363,7 +363,7 @@ def test_acquire_with_new_optimization(self, benchmark, sync_limiter):
 Example GitHub Actions workflow for integration tests:
 
 ```yaml
-# .github/workflows/ci.yml
+# .github/workflows/ci-tests.yml
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ title: ""
 [![Conda version](https://img.shields.io/conda/v/conda-forge/zae-limiter?style=flat-square)](https://anaconda.org/conda-forge/zae-limiter)
 [![Python versions](https://img.shields.io/pypi/pyversions/zae-limiter?style=flat-square)](https://pypi.org/project/zae-limiter/)
 [![License](https://img.shields.io/pypi/l/zae-limiter?style=flat-square)](https://github.com/zeroae/zae-limiter/blob/main/LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci.yml?branch=main&style=flat-square)](https://github.com/zeroae/zae-limiter/actions/workflows/ci.yml)
+[![Lint](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci-lint.yml?branch=main&style=flat-square&label=lint)](https://github.com/zeroae/zae-limiter/actions/workflows/ci-lint.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/zeroae/zae-limiter/ci-tests.yml?branch=main&style=flat-square&label=tests)](https://github.com/zeroae/zae-limiter/actions/workflows/ci-tests.yml)
 [![codecov](https://img.shields.io/codecov/c/github/zeroae/zae-limiter?style=flat-square)](https://codecov.io/gh/zeroae/zae-limiter)
 
 A rate limiting library backed by DynamoDB using the token bucket algorithm.


### PR DESCRIPTION
## Summary

- Replace single CI badge with separate Lint and Tests badges after workflow split
- Update badge URLs from `ci.yml` to `ci-lint.yml` and `ci-tests.yml`
- Update example workflow reference in testing documentation

## Files Changed

| File | Change |
|------|--------|
| `README.md` | Replace CI badge with Lint + Tests badges |
| `docs/index.md` | Replace CI badge with Lint + Tests badges |
| `docs/contributing/testing.md` | Update workflow filename in example |

## Test plan

- [x] Verify badge URLs point to correct workflows (`ci-lint.yml`, `ci-tests.yml`)

🤖 Generated with [Claude Code](https://claude.ai/code)