### PR TITLE
🐛 fix(docs): use absolute URLs for logo images on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/zae-limiter-dark-bg.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/zae-limiter-white-bg.svg">
-    <img alt="zae-limiter" src="docs/assets/zae-limiter-white-bg.svg" width="50%">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/zeroae/zae-limiter/main/docs/assets/zae-limiter-dark-bg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/zeroae/zae-limiter/main/docs/assets/zae-limiter-white-bg.svg">
+    <img alt="zae-limiter" src="https://raw.githubusercontent.com/zeroae/zae-limiter/main/docs/assets/zae-limiter-white-bg.svg" width="50%">
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary
- Convert relative README logo paths to absolute raw.githubusercontent.com URLs
- Fixes broken image placeholders when viewed on PyPI (relative paths only work on GitHub)

## Test plan
- [ ] Verify logo images display correctly on GitHub README
- [ ] Publish to TestPyPI and verify logo images render properly

Closes #302

🤖 Generated with [Claude Code](https://claude.ai/code)