### PR TITLE
🐛 fix(ci): docs workflow cancelling tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,11 +6,7 @@ on:
       - main
       - 'release/v*'
       - 'release/[0-9]*'
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - 'pyproject.toml'
+    # No paths filter - run on all pushes to ensure workflow_run always triggers
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
@@ -30,10 +26,9 @@ permissions:
   contents: write
   pull-requests: write
 
-# Share concurrency group with docs to prevent gh-pages race conditions
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: false
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify-sync:
@@ -206,6 +201,9 @@ jobs:
   benchmark-moto:
     needs: verify-sync
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:
@@ -233,6 +231,9 @@ jobs:
     needs: verify-sync
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write-${{ github.ref }}
+      cancel-in-progress: false
     services:
       localstack:
         image: localstack/localstack:4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,14 @@ on:
       - main
       - 'release/v*'
       - 'release/[0-9]*'
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+    branches:
+      - main
+      - 'release/v*'
+      - 'release/[0-9]*'
 
 permissions:
   contents: write
@@ -25,6 +33,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -68,12 +77,17 @@ jobs:
         run: uv run mkdocs build --strict
 
   deploy:
-    if: github.event_name == 'push'
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
-    needs: build
+    concurrency:
+      group: gh-pages-write-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

Fixes concurrency group conflict where docs.yml was cancelling ci-tests.yml, and ensures docs are only deployed after tests pass successfully on push to main.

## Changes

### Concurrency Groups (Issue #314)

Changed from a shared `docs-$ref` group to separate groups:

| Workflow/Job | Old Group | New Group | Cancel-in-Progress |
|--------------|-----------|-----------|-------------------|
| ci-tests.yml (workflow) | `docs-$ref` | `ci-tests-$ref` | `true` |
| docs.yml (workflow) | `docs-$ref` | `docs-$ref` | `true` |
| Benchmark jobs | (none) | `gh-pages-write-$ref` | `false` |
| Docs deploy job | (none) | `gh-pages-write-$ref` | `false` |

### Workflow Triggers

**ci-tests.yml:**
- Removed `paths` filter from push trigger to ensure workflow_run always fires

**docs.yml:**
- Added `workflow_run` trigger to wait for Tests workflow completion
- Deploy job now runs on `workflow_run` success or tag push (not all pushes)
- Build job skips on `workflow_run` events

### Coordination

Jobs that write to gh-pages branch (benchmark-moto, benchmark-localstack, docs deploy) now use job-level `gh-pages-write-$ref` concurrency group with `cancel-in-progress: false` to prevent race conditions.

## Test plan

- [x] Push to main triggers Tests workflow without cancellation
- [x] Docs deploy waits for Tests workflow completion
- [x] PRs can still build docs without waiting for tests
- [x] Tag pushes deploy docs immediately
- [x] Benchmark jobs coordinate with docs deployment

Closes #314

🤖 Generated with [Claude Code](https://claude.ai/code)