### PR TITLE
✨ feat(infra): add stack type tagging, discovery filtering, and CFN exports

### DIFF
--- a/src/zae_limiter/infra/cfn_template.yaml
+++ b/src/zae_limiter/infra/cfn_template.yaml
@@ -134,6 +134,14 @@ Parameters:
       (Optional) Custom name for the read-only IAM role.
       If empty, uses default: {stack_name}-read.
 
+  RoleNameFormat:
+    Type: String
+    Default: ''
+    Description: >
+      (Optional) Format template for IAM role names. Use {} as placeholder.
+      Example: 'PowerUserPB-{}' produces 'PowerUserPB-mystack-aggr'.
+      Exported for use by dependent stacks (e.g., stress test).
+
   AcquireOnlyPolicyName:
     Type: String
     Default: ''
@@ -1069,3 +1077,32 @@ Outputs:
     Value: !Ref ReadOnlyRole
     Export:
       Name: !Sub ${AWS::StackName}-ReadOnlyRoleName
+
+  # -------------------------------------------------------------------------
+  # IAM Configuration Outputs (for stress test stack to import)
+  # -------------------------------------------------------------------------
+
+  PermissionBoundaryArn:
+    Description: Permission boundary ARN used for IAM roles (empty if none)
+    Value: !If
+      - HasPermissionBoundary
+      - !If
+        - PermissionBoundaryIsArn
+        - !Ref PermissionBoundary
+        - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${PermissionBoundary}'
+      - ''
+    Export:
+      Name: !Sub ${AWS::StackName}-PermissionBoundaryArn
+
+  RoleNameFormat:
+    Description: Role name format template (empty if using defaults)
+    Value: !Ref RoleNameFormat
+    Export:
+      Name: !Sub ${AWS::StackName}-RoleNameFormat
+
+  CodeBucketName:
+    Condition: DeployAuditArchive
+    Description: S3 bucket name for deployment artifacts (reuses audit archive bucket)
+    Value: !Ref AuditArchiveBucket
+    Export:
+      Name: !Sub ${AWS::StackName}-CodeBucketName

--- a/src/zae_limiter/infra/stack_manager.py
+++ b/src/zae_limiter/infra/stack_manager.py
@@ -26,6 +26,7 @@ SCHEMA_VERSION_TAG_KEY = f"{VERSION_TAG_PREFIX}schema-version"
 MANAGED_BY_TAG_KEY = "ManagedBy"
 MANAGED_BY_TAG_VALUE = "zae-limiter"
 NAME_TAG_KEY = f"{VERSION_TAG_PREFIX}name"
+TYPE_TAG_KEY = f"{VERSION_TAG_PREFIX}type"
 
 
 class StackManager:
@@ -143,6 +144,7 @@ class StackManager:
             "acquire_only_policy_name": "AcquireOnlyPolicyName",
             "full_access_policy_name": "FullAccessPolicyName",
             "readonly_policy_name": "ReadOnlyPolicyName",
+            "role_name_format": "RoleNameFormat",
             "enable_audit_archival": "EnableAuditArchival",
             "audit_archive_glacier_days": "AuditArchiveGlacierTransitionDays",
             "enable_tracing": "EnableTracing",
@@ -210,6 +212,7 @@ class StackManager:
         # Discovery tags (override user tags on collision)
         tag_dict[MANAGED_BY_TAG_KEY] = MANAGED_BY_TAG_VALUE
         tag_dict[NAME_TAG_KEY] = user_name
+        tag_dict[TYPE_TAG_KEY] = "limiter"
 
         # Version tags (override user tags on collision)
         for tag in self._get_version_tags():

--- a/src/zae_limiter/infra/sync_stack_manager.py
+++ b/src/zae_limiter/infra/sync_stack_manager.py
@@ -27,6 +27,7 @@ SCHEMA_VERSION_TAG_KEY = f"{VERSION_TAG_PREFIX}schema-version"
 MANAGED_BY_TAG_KEY = "ManagedBy"
 MANAGED_BY_TAG_VALUE = "zae-limiter"
 NAME_TAG_KEY = f"{VERSION_TAG_PREFIX}name"
+TYPE_TAG_KEY = f"{VERSION_TAG_PREFIX}type"
 
 
 class SyncStackManager:
@@ -124,6 +125,7 @@ class SyncStackManager:
             "acquire_only_policy_name": "AcquireOnlyPolicyName",
             "full_access_policy_name": "FullAccessPolicyName",
             "readonly_policy_name": "ReadOnlyPolicyName",
+            "role_name_format": "RoleNameFormat",
             "enable_audit_archival": "EnableAuditArchival",
             "audit_archive_glacier_days": "AuditArchiveGlacierTransitionDays",
             "enable_tracing": "EnableTracing",
@@ -182,6 +184,7 @@ class SyncStackManager:
             tag_dict.update(user_tags)
         tag_dict[MANAGED_BY_TAG_KEY] = MANAGED_BY_TAG_VALUE
         tag_dict[NAME_TAG_KEY] = user_name
+        tag_dict[TYPE_TAG_KEY] = "limiter"
         for tag in self._get_version_tags():
             tag_dict[tag["Key"]] = tag["Value"]
         return [{"Key": k, "Value": v} for k, v in tag_dict.items()]

--- a/src/zae_limiter/models.py
+++ b/src/zae_limiter/models.py
@@ -568,6 +568,9 @@ class LimiterInfo:
     lambda_version: str | None = None
     schema_version: str | None = None
 
+    # Stack type (e.g., "limiter", "load-test")
+    stack_type: str | None = None
+
     @property
     def is_healthy(self) -> bool:
         """Stack is in a stable, operational state."""
@@ -894,6 +897,8 @@ class StackOptions:
         # Generate 4 separate role name parameters (ADR-116)
         # get_role_name returns str when role_name_format is set (which we check above)
         if self.role_name_format and stack_name:
+            # Export the format template for dependent stacks (e.g., stress test)
+            params["role_name_format"] = self.role_name_format
             aggregator_role = self.get_role_name(stack_name, "aggr")
             app_role = self.get_role_name(stack_name, "app")
             admin_role = self.get_role_name(stack_name, "admin")

--- a/tests/unit/test_sync_discovery.py
+++ b/tests/unit/test_sync_discovery.py
@@ -369,6 +369,43 @@ class TestDualDiscovery:
         assert len(limiters) == 1
         assert limiters[0].user_name == "fallback-app"
 
+    def test_filters_by_stack_type(self) -> None:
+        """list_limiters filters results when stack_type is specified."""
+        limiter_stack = LimiterInfo(
+            stack_name="my-limiter",
+            user_name="my-limiter",
+            region="us-east-1",
+            stack_status="CREATE_COMPLETE",
+            creation_time="2024-01-15T10:30:00",
+            stack_type="limiter",
+        )
+        load_stack = LimiterInfo(
+            stack_name="my-load-test",
+            user_name="my-load-test",
+            region="us-east-1",
+            stack_status="CREATE_COMPLETE",
+            creation_time="2024-01-15T11:00:00",
+            stack_type="load-test",
+        )
+        with (
+            patch.object(
+                SyncInfrastructureDiscovery,
+                "_discover_via_tagging_api",
+                new_callable=MagicMock,
+                return_value=[limiter_stack, load_stack],
+            ),
+            patch.object(
+                SyncInfrastructureDiscovery,
+                "_discover_via_describe_stacks",
+                new_callable=MagicMock,
+                return_value=[],
+            ),
+        ):
+            with SyncInfrastructureDiscovery(region="us-east-1") as discovery:
+                limiters = discovery.list_limiters(stack_type="limiter")
+        assert len(limiters) == 1
+        assert limiters[0].stack_name == "my-limiter"
+
 
 class TestStackOptionsWithTags:
     """Tests for StackOptions tags field."""


### PR DESCRIPTION
## Summary

- Add `TYPE_TAG_KEY` to stack tags so limiter and load-test stacks can be distinguished
- Export `PermissionBoundaryArn`, `RoleNameFormat`, and `CodeBucketName` from CFN stack for use by dependent stacks (e.g., load testing)
- Add `stack_type` field to `LimiterInfo` model
- Add `stack_type` filter to `list_limiters()` in discovery
- Export `role_name_format` from `StackOptions.to_cfn_params()`

## Test plan

- [x] Unit tests for `list_limiters(stack_type="limiter")` filtering (async + sync)
- [x] Pre-commit hooks pass (ruff, mypy, cfn-lint, partition check)
- [x] 100% patch coverage
- [x] CI passes

Closes #341
Part of #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)