### PR TITLE
👷 ci: reduce Python matrix to 3.12-only on PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.11", "3.12"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.11", "3.12"]') }}
     services:
       localstack:
         image: localstack/localstack:4
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.11", "3.12"]') }}
     services:
       localstack:
         image: localstack/localstack:4


### PR DESCRIPTION
## Summary
- Reduce CI Python test matrix from `["3.11", "3.12"]` to `["3.12"]` on pull requests
- Full `["3.11", "3.12"]` matrix still runs on push to main
- Applies to unit, integration, and e2e test jobs
- Halves CI compute time on PRs while keeping full coverage on merge

## Test plan
- [x] Verify PR CI runs only Python 3.12 jobs
- [x] Verify push-to-main CI still runs both 3.11 and 3.12

🤖 Generated with [Claude Code](https://claude.ai/code)