### PR TITLE
👷 ci: skip integration and e2e tests on draft PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -84,6 +84,7 @@ jobs:
           fail_ci_if_error: false
 
   integration:
+    if: ${{ !github.event.pull_request.draft }}
     needs: verify-sync
     runs-on: ubuntu-latest
     strategy:
@@ -146,6 +147,7 @@ jobs:
           fail_ci_if_error: false
 
   e2e:
+    if: ${{ !github.event.pull_request.draft }}
     needs: verify-sync
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- Skip `integration` and `e2e` CI jobs when a PR is in draft mode
- Adds `if: ${{ !github.event.pull_request.draft }}` condition to both jobs in `ci-tests.yml`
- Reduces CI resource usage during early development iterations

## Test plan
- [x] Verify integration and e2e jobs are skipped on this draft PR
- [x] Mark PR as ready for review and verify integration and e2e jobs run

🤖 Generated with [Claude Code](https://claude.ai/code)