### PR TITLE
👷 ci: make benchmark-localstack a manual-only job

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,6 +21,11 @@ on:
       - 'scripts/**'
       - 'pyproject.toml'
   workflow_dispatch:
+    inputs:
+      run-benchmark-localstack:
+        description: 'Run LocalStack benchmarks'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -233,7 +238,7 @@ jobs:
 
   benchmark-localstack:
     needs: verify-sync
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-benchmark-localstack }}
     runs-on: ubuntu-latest
     concurrency:
       group: gh-pages-write-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Move LocalStack benchmarks from automatic CI runs to manual `workflow_dispatch` with a checkbox input
- Benchmarks no longer run on push/PR events, reducing CI time
- Can be triggered manually via Actions tab or `gh workflow run ci-tests.yml -f run-benchmark-localstack=true`

## Test plan
- [x] Verify benchmark-localstack job is skipped on regular push/PR
- [x] Verify manual dispatch with checkbox triggers the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)