### PR TITLE
🐛 fix(test): replace print-based warnings with warnings.warn in test cleanup (#175)

### DIFF
--- a/tests/benchmark/test_aws.py
+++ b/tests/benchmark/test_aws.py
@@ -23,6 +23,7 @@ Example: GEVENT=1 pytest tests/benchmark/test_aws.py --run-aws -o "addopts=" -v
 import os
 import time
 import uuid
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -94,7 +95,7 @@ class TestAWSLatencyBenchmarks:
         try:
             repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.benchmark(group="aws-acquire")
     def test_acquire_single_limit_aws_latency(self, benchmark, aws_benchmark_limiter):
@@ -230,7 +231,7 @@ class TestAWSThroughputBenchmarks:
         try:
             repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     def test_sequential_throughput_aws(self, aws_throughput_limiter):
         """Measure max sequential TPS on real AWS.
@@ -447,7 +448,7 @@ class TestAWSCascadeSpeculativeComparison:
         try:
             repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.fixture(scope="class", params=[False, True], ids=["baseline", "speculative"])
     def aws_speculative_limiter(self, request, aws_speculative_stack):
@@ -627,7 +628,7 @@ class TestAWSCascadeBenchmarks:
         try:
             repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.fixture(scope="class")
     def aws_cascade_limiter(self, aws_cascade_stack):

--- a/tests/e2e/test_aws.py
+++ b/tests/e2e/test_aws.py
@@ -25,6 +25,7 @@ Resources are cleaned up after tests, but verify via AWS Console.
 
 import asyncio
 import time
+import warnings
 from datetime import UTC, datetime
 
 import pytest
@@ -109,7 +110,7 @@ class TestE2EAWSFullWorkflow:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio(loop_scope="class")
     async def test_complete_aws_workflow(self, aws_limiter):
@@ -359,7 +360,7 @@ class TestE2EAWSUsageSnapshots:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio(loop_scope="class")
     @pytest.mark.slow
@@ -524,7 +525,7 @@ class TestE2EAWSRateLimiting:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio(loop_scope="class")
     async def test_high_throughput_operations(self, aws_limiter_minimal):
@@ -646,7 +647,7 @@ class TestE2EAWSXRayTracingEnabled:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio(loop_scope="class")
     async def test_lambda_tracing_enabled(
@@ -880,7 +881,7 @@ class TestE2EAWSXRayTracingDisabled:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio(loop_scope="class")
     async def test_lambda_tracing_disabled(
@@ -956,7 +957,7 @@ class TestE2EAWSSpeculativeConsume:
         try:
             await repo.delete_table()
         except Exception as e:
-            print(f"Warning: Table cleanup failed: {e}")
+            warnings.warn(f"Table cleanup failed: {e}", ResourceWarning, stacklevel=2)
         await repo.close()
 
     @pytest.mark.asyncio(loop_scope="class")

--- a/tests/e2e/test_aws_discovery.py
+++ b/tests/e2e/test_aws_discovery.py
@@ -19,6 +19,8 @@ WARNING: These tests create real AWS resources and may incur charges.
 Resources are cleaned up after tests, but verify via AWS Console.
 """
 
+import warnings
+
 import pytest
 
 from zae_limiter import RateLimiter, Repository, StackOptions
@@ -74,7 +76,7 @@ class TestTagBasedDiscovery:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio
     async def test_stack_has_managed_by_tag(self, deployed_limiter, discovery_name):
@@ -190,7 +192,7 @@ class TestDiscoveryWithUserTags:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio
     async def test_user_tags_applied_alongside_managed_tags(self, tagged_limiter, discovery_name):

--- a/tests/e2e/test_config_storage.py
+++ b/tests/e2e/test_config_storage.py
@@ -17,6 +17,8 @@ To run these tests locally:
 Note: These tests use minimal stack options (no aggregator) for faster execution.
 """
 
+import warnings
+
 import pytest
 import pytest_asyncio  # type: ignore[import-untyped]
 from click.testing import CliRunner
@@ -345,7 +347,7 @@ class TestE2EConfigCLIWorkflow:
         try:
             repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     def test_resource_config_cli_workflow(self, e2e_limiter, cli_runner, localstack_endpoint):
         """

--- a/tests/e2e/test_localstack.py
+++ b/tests/e2e/test_localstack.py
@@ -24,6 +24,7 @@ LocalStack to spawn Lambda functions as Docker containers.
 """
 
 import asyncio
+import warnings
 
 import pytest
 import pytest_asyncio
@@ -942,7 +943,7 @@ class TestE2ECloudFormationStackVariations:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
     @pytest.mark.asyncio
     async def test_cloudformation_aggregator_no_alarms(
@@ -971,7 +972,7 @@ class TestE2ECloudFormationStackVariations:
         try:
             await repo.delete_stack()
         except Exception as e:
-            print(f"Warning: Stack cleanup failed: {e}")
+            warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
 
 
 class TestE2ERoleNaming:

--- a/tests/fixtures/stacks.py
+++ b/tests/fixtures/stacks.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -102,7 +103,7 @@ async def destroy_shared_stack(repo: Repository) -> None:
     try:
         await repo.delete_stack()
     except Exception as e:
-        print(f"Warning: Stack cleanup failed: {e}")
+        warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
     await repo.close()
 
 
@@ -170,7 +171,7 @@ def cleanup_shared_stacks(tmp_root: Path) -> None:
             repo.delete_stack()
             repo.close()
         except Exception as e:
-            print(f"Warning: cleanup of {data_file.stem} failed: {e}")
+            warnings.warn(f"cleanup of {data_file.stem} failed: {e}", ResourceWarning, stacklevel=2)
 
 
 # Session-scoped shared stack fixtures

--- a/tests/integration/test_namespace_isolation.py
+++ b/tests/integration/test_namespace_isolation.py
@@ -12,6 +12,7 @@ To run:
 """
 
 import uuid
+import warnings
 
 import pytest
 
@@ -200,7 +201,7 @@ class TestNamespaceIsolationViaBuilder:
             try:
                 await repo_default.delete_stack()
             except Exception as e:
-                print(f"Warning: Stack cleanup failed: {e}")
+                warnings.warn(f"Stack cleanup failed: {e}", ResourceWarning, stacklevel=2)
             await repo_default.close()
             await repo_a.close()
             await repo_b.close()


### PR DESCRIPTION
## Summary

- Replace all 18 `print(f"Warning: ...")` calls in test fixture cleanup code with `warnings.warn(..., ResourceWarning, stacklevel=2)`
- Adds `import warnings` to 7 test files
- Cleanup failures (orphaned stacks) now surface in pytest warning summaries instead of being silently swallowed

## Test plan

- [x] Zero `print(f"Warning: ...")` statements remaining in test cleanup code
- [x] All 18 sites use `warnings.warn(..., ResourceWarning, stacklevel=2)`
- [x] Unit tests pass (2350 passed)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)