### PR TITLE
📝 docs(adr): ADR consistency cleanup — numbering, nav, format, cross-refs

### DIFF
--- a/docs/adr/013-module-documentation-parity.md
+++ b/docs/adr/013-module-documentation-parity.md
@@ -1,6 +1,6 @@
 # ADR-013: Bidirectional Source-Documentation Parity
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-01-19
 **Supersedes:** ADR-012
 

--- a/docs/adr/100-centralized-config.md
+++ b/docs/adr/100-centralized-config.md
@@ -5,6 +5,8 @@
 **Issue:** [#129](https://github.com/zeroae/zae-limiter/issues/129)
 **Milestone:** v0.5.0
 
+> **Note (post-v0.5.0):** This is the original index for the centralized-config design. Two sub-decisions have since been superseded — the hierarchy expanded from three to four levels ([ADR-118](118-four-level-config-hierarchy.md) supersedes [ADR-102](102-config-hierarchy.md)) and limit resolution/caching moved to the Repository protocol ([ADR-122](122-resolve-limits-on-repository.md) supersedes [ADR-103](103-config-caching.md)). The original per-limit `#LIMIT#` config keys were replaced by composite `#CONFIG` items ([ADR-114](114-composite-bucket-items.md), [ADR-115](115-add-based-writes-lazy-refill.md)). See the updated access patterns below.
+
 ## Context
 
 zae-limiter is a distributed rate limiting library where multiple clients must behave consistently. Currently:
@@ -21,8 +23,8 @@ Implement centralized configuration with these architectural choices:
 | Decision | ADR | Summary |
 |----------|-----|---------|
 | Schema format | [ADR-101](101-flat-schema-config.md) | Flat schema (no nested `data.M`) for atomic counters |
-| Config hierarchy | [ADR-102](102-config-hierarchy.md) | Three levels: System > Resource > Entity |
-| Caching strategy | [ADR-103](103-config-caching.md) | 60s TTL with negative caching |
+| Config hierarchy | [ADR-102](102-config-hierarchy.md) *(superseded by [ADR-118](118-four-level-config-hierarchy.md))* | Three levels: System > Resource > Entity — later expanded to four |
+| Caching strategy | [ADR-103](103-config-caching.md) *(superseded by [ADR-122](122-resolve-limits-on-repository.md))* | 60s TTL with negative caching; resolution later moved to the Repository protocol |
 | API behavior | [ADR-104](104-stored-limits-default.md) | Stored limits as default |
 | Read consistency | [ADR-105](105-eventual-consistency.md) | Eventually consistent reads |
 
@@ -41,11 +43,13 @@ Implement centralized configuration with these architectural choices:
 
 ## Access Patterns Added
 
-| Pattern | Query | Index |
-|---------|-------|-------|
-| Get system config | `PK=SYSTEM#, SK begins_with #LIMIT#` | Primary |
-| Get resource config | `PK=RESOURCE#{resource}, SK begins_with #LIMIT#` | Primary |
-| Get entity config | `PK=ENTITY#{id}, SK begins_with #LIMIT#` | Primary |
+> The original per-limit sort keys (`SK begins_with #LIMIT#`) were replaced by composite config items ([ADR-114](114-composite-bucket-items.md), [ADR-118](118-four-level-config-hierarchy.md)): a single `#CONFIG` item per level, namespace-prefixed with `{ns}/`. Both are shown below.
+
+| Pattern | Query (v0.5.0, original) | Current |
+|---------|--------------------------|---------|
+| Get system config | `PK=SYSTEM#, SK begins_with #LIMIT#` | `PK={ns}/SYSTEM#, SK=#CONFIG` |
+| Get resource config | `PK=RESOURCE#{resource}, SK begins_with #LIMIT#` | `PK={ns}/RESOURCE#{resource}, SK=#CONFIG` |
+| Get entity config | `PK=ENTITY#{id}, SK begins_with #LIMIT#` | `PK={ns}/ENTITY#{id}, SK=#CONFIG#{resource}` |
 
 ## Implementation
 

--- a/docs/adr/107-iam-roles-for-application-access.md
+++ b/docs/adr/107-iam-roles-for-application-access.md
@@ -1,6 +1,6 @@
 # ADR-107: IAM Roles for Application Access
 
-**Status:** Accepted
+**Status:** Accepted (IAM defaults partially superseded by [ADR-117](117-managed-policies-by-default.md))
 **Date:** 2026-01-19
 **Issue:** [#132](https://github.com/zeroae/zae-limiter/issues/132)
 
@@ -13,6 +13,8 @@ The CloudFormation stack currently only creates the Lambda execution role for th
 ## Decision
 
 The CloudFormation stack creates three optional IAM roles (AppRole, AdminRole, ReadOnlyRole) with least-privilege DynamoDB permissions, enabled by default and controlled via `--no-iam-roles` flag or `StackOptions.create_iam_roles=False`.
+
+> **Partially superseded by [ADR-117](117-managed-policies-by-default.md):** managed *policies* are now created by default and IAM *roles* are opt-in (`create_iam_roles=True` / `--create-iam-roles`). The "enabled by default / `--no-iam-roles`" default above no longer reflects current behavior. The three-tier app/admin/read-only access model is retained; [ADR-124](124-policy-rename-clarity.md) later renamed the policies to AcquireOnly/FullAccess/ReadOnly.
 
 ## Consequences
 

--- a/docs/adr/121-native-sync-unasync.md
+++ b/docs/adr/121-native-sync-unasync.md
@@ -1,8 +1,7 @@
 # ADR-121: Native Sync Implementation via Unasync Pattern
 
-## Status
-
-Accepted
+**Status:** Accepted
+**Date:** 2026-02-02
 
 ## Context
 

--- a/docs/adr/124-policy-rename-clarity.md
+++ b/docs/adr/124-policy-rename-clarity.md
@@ -1,4 +1,4 @@
-# ADR-121: Rename IAM Policies for Clarity
+# ADR-124: Rename IAM Policies for Clarity
 
 **Status:** Accepted
 **Date:** 2026-02-02

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,3 +170,19 @@ nav:
           - ADR-111 Flatten All Records: adr/111-flatten-all-records.md
           - ADR-112 Cascade Per Entity: adr/112-cascade-per-entity.md
           - ADR-113 Lambda Packaging: adr/113-lambda-packaging.md
+      - Composite Items (v0.8.0):
+          - ADR-114 Composite Bucket Items: adr/114-composite-bucket-items.md
+          - ADR-115 ADD-Based Writes: adr/115-add-based-writes-lazy-refill.md
+      - IAM Resources (v0.9.0):
+          - ADR-116 IAM Role Naming: adr/116-iam-role-naming.md
+          - ADR-117 Managed Policies by Default: adr/117-managed-policies-by-default.md
+          - ADR-124 Rename IAM Policies: adr/124-policy-rename-clarity.md
+      - Config Hierarchy & TTL (v0.8.0+):
+          - ADR-118 Four-Level Config Hierarchy: adr/118-four-level-config-hierarchy.md
+          - ADR-119 Bucket TTL Strategy: adr/119-bucket-ttl-strategy.md
+          - ADR-120 Bucket Param Sync: adr/120-bucket-param-sync.md
+      - Sync & Repository (v0.9.0+):
+          - ADR-121 Native Sync (Unasync): adr/121-native-sync-unasync.md
+          - ADR-122 Resolve Limits on Repository: adr/122-resolve-limits-on-repository.md
+      - Pre-1.0 Hardening (v0.10.0+):
+          - ADR-123 Local Secondary Indexes: adr/123-local-secondary-indexes.md


### PR DESCRIPTION
## Summary

This PR collects four commits of ADR consistency cleanup on `main`:

1. **Resolve the duplicate ADR-121** — two Accepted ADRs both claimed number 121. Native-sync keeps 121 (earlier file, referenced externally by CLAUDE.md); the IAM policy-rename ADR is renumbered `121 → 124` (next free number after `123-local-secondary-indexes`). Structural collision fix only — no decision content changed, consistent with the ADR immutability rule.
2. **Normalize ADR-121 (native-sync) status header** — it used a `## Status` heading with the value on a separate line; normalized to the `**Status:**` / `**Date:**` inline format mandated by ADR-000 (Date `2026-02-02`, from the file's creation commit).
3. **Add ADRs 114-124 to the mkdocs navigation** — the nav previously stopped at ADR-113, leaving 114-124 unreachable from the docs site. Added thematic groups covering 114-124 and reflecting the corrected numbering.
4. **Resolve cross-ADR consistency issues** surfaced by `/adr consistency`:
   - **ADR-107**: annotate its partial supersession by ADR-117. Two Accepted ADRs asserted opposite IAM defaults (roles-by-default vs policies-by-default); flag it in the status line and add a Decision note pointing to ADR-117 (current default) and ADR-124 (policy rename) so the reversed default is unambiguous.
   - **ADR-100**: this Proposed index still presented superseded sub-decisions (102→118, 103→122) as authoritative and used the pre-composite `#LIMIT#` schema. Mark the superseded rows and show the current composite `#CONFIG` keys.
   - **ADR-013**: accept it. It was Proposed yet already superseded ADR-012 — an invalid state. Its decision is complete and already operationalized as `.claude/rules/docs-parity.md`, so finalize the status.

This is the **main-branch half of a coordinated cleanup**. The other halves renumber ADRs on open PRs so the whole sequence is collision-free:

- **#304**: `121 → 125`
- **#393**: `123-129 → 126-132` (plus the same inherited `121 → 124` fix)

Together these yield a collision-free ADR sequence **121-132**.

## Test plan

- [ ] `ls docs/adr/12*.md` shows no duplicate ADR numbers
- [ ] `grep -rn "121-policy-rename" docs/` returns no stale references
- [ ] ADR-124 header reads `# ADR-124: Rename IAM Policies for Clarity`
- [ ] ADR-121 header uses the `**Status:**` / `**Date:**` inline format
- [ ] `mkdocs build` reaches ADRs 114-124 from the nav
- [ ] ADR-107 status line notes the partial supersession by ADR-117
- [ ] ADR-100 marks the 102→118 / 103→122 superseded rows and shows `#CONFIG` keys
- [ ] ADR-013 status reads Accepted

🤖 Generated with [Claude Code](https://claude.ai/code)