### PR TITLE
🐛 fix(ci): strip ordering markers from changelog section headers

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,7 +17,7 @@ body = """
     ## [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ### {{ group | upper_first }}
+    ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
         - {% if commit.scope %}**{{commit.scope}}**: {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))\
     {% endfor %}


### PR DESCRIPTION
## Summary
- git-cliff section group names in `cliff.toml` embed `<!-- N -->` ordering markers (e.g. `<!-- 4 -->Refactoring`) to control section order. The changelog body template rendered the raw group name, leaking the marker into rendered headers — visible as `### <!-- 4 -->Refactoring` in the v0.10.2 changelog and GitHub Release notes.
- Fix: add the canonical `striptags | trim` filters to the group header in the body template (`### {{ group | striptags | trim | upper_first }}`). This is display-only; section ordering is unchanged.

## Test plan
- [x] Rendered the full changelog locally with `uvx git-cliff --config cliff.toml` — all 12 section headers (Features, Bug Fixes, Refactoring, etc.) render cleanly with zero `### <!--` leaks
- [x] Confirmed the v0.10.2 section renders as `### Refactoring`

🤖 Generated with [Claude Code](https://claude.ai/code)